### PR TITLE
Added missing doc strings for all geoms + others

### DIFF
--- a/docs/examples/Contributors/HowTo.jl
+++ b/docs/examples/Contributors/HowTo.jl
@@ -20,7 +20,7 @@
 #     Install the following dependencies in your system via pip, i.e.
 #     - `pip install mkdocs pygments python-markdown-math`
 #     - `pip install mkdocs-material pymdown-extensions mkdocstrings`
-#     - `pip mknotebooks pytkdocs_tweaks mkdocs_include_exclude_files jinja2 mkdocs-video`
+#     - `pip install mknotebooks pytkdocs_tweaks mkdocs_include_exclude_files jinja2 mkdocs-video`
 
 # Then simply go to your `docs` env and activate it, i.e.
 

--- a/docs/examples/Contributors/HowTo.jl
+++ b/docs/examples/Contributors/HowTo.jl
@@ -1,44 +1,60 @@
-# ## Contribute to Documentation
-# Contributing with examples can be done by first creating a new file example
-# [here](https://tidierorg.github.io/TidierPlots.jl/tree/main/docs/examples/UserGuide)
+md"""
+## Contribute to Documentation
 
-# !!! info
-#     - `your_new_file.jl` at `docs/examples/UserGuide/`
+Examples are written and rendered using [Literate.jl](https://github.com/fredrikekre/Literate.jl).
+This allows you to write your example in a `.jl` file and annotate it with markdown.
 
-# Once this is done you need to add a new entry [here](https://tidierorg.github.io/TidierPlots.jl/blob/main/docs/mkdocs.yml)
-# at the bottom and the appropriate level.
+Contributing with examples can be done by first creating a new example file in the
+[docs/examples/UserGuide](https://github.com/TidierOrg/TidierPlots.jl/tree/main/docs/examples/UserGuide)
+directory:
 
-# !!! info
-#     Your new entry should look like:
-#     - `"Your title example" : "examples/generated/UserGuide/your_new_file.md"`
+!!! info
+    - `your_new_file.jl` at `docs/examples/UserGuide/`
 
-# ## Build docs locally
-# If you want to take a look at the docs locally before doing a PR
-# follow the next steps:
+Once this is done you need to add a new nav entry to the
+[mkdocs.yml](https://github.com/TidierOrg/TidierPlots.jl/blob/main/docs/mkdocs.yml) file
+at the bottom at the appropriate level:
 
-# !!! warning "build docs locally"
-#     Install the following dependencies in your system via pip, i.e.
-#     - `pip install mkdocs pygments python-markdown-math`
-#     - `pip install mkdocs-material pymdown-extensions mkdocstrings`
-#     - `pip install mknotebooks pytkdocs_tweaks mkdocs_include_exclude_files jinja2 mkdocs-video`
+!!! info
+    Your new entry should look like:
+    - `"Your title example" : "examples/generated/UserGuide/your_new_file.md"`
 
-# Then simply go to your `docs` env and activate it, i.e.
 
-# `docs> julia`
+## Build docs locally
 
-# `julia> ]`
+If you want to take a look at the docs locally before doing a PR, then follow the next steps:
 
-# `(docs) pkg> activate .`
+!!! warning "Build docs locally"
+    Install the following dependencies in your system via pip, i.e.
+    - `pip install mkdocs pygments python-markdown-math`
+    - `pip install mkdocs-material pymdown-extensions mkdocstrings`
+    - `pip install mknotebooks pytkdocs_tweaks mkdocs_include_exclude_files jinja2 mkdocs-video`
 
-# Next, run the scripts:
-# !!! info
-#     Generate files and build docs by running:
-#     - `genfiles.jl`
-#     - `make.jl`
+Next you will need to activate the `docs` environment:
 
-# Now go to your `terminal` in the same path `docs>` and run:
+```
+TidierPlots.jl> julia --project=docs/ -e 'using Pkg; pkg"dev ."; Pkg.instantiate()'
+```
 
-# `mkdocs serve`
+Generate files and build the docs by running the following in your terminal:
 
-# This should output `http://127.0.0.1:8000`, copy/paste this into your
-# browser and you are all set.
+```
+TidierPlots.jl> julia --project=docs/ --color=yes docs/genfiles.jl
+TidierPlots.jl> julia --project=docs/ --color=yes docs/make.jl
+```
+
+!!! info "Set environment variables"
+    You may want to set additional Julia environment variables before running `make.jl`.
+    This will enable additional debugging messages while building the docs.
+    - `ENV["JULIA_DEBUG"] = "Documenter"`
+
+Finally, in your `terminal`, change directory to the `docs` folder and run:
+
+```
+docs> mkdocs serve
+```
+
+This should output `http://127.0.0.1:8000`, copy/paste this into your browser and you are
+all set. You can leave this server running while making changes to the docs. You can open
+a new terminal and re-run `genfiles.jl` and `make.jl` to see the changes.
+"""

--- a/docs/examples/UserGuide/docs_bridge.jl
+++ b/docs/examples/UserGuide/docs_bridge.jl
@@ -7,13 +7,15 @@ penguins = dropmissing(DataFrame(PalmerPenguins.load()));
 
 # ## `ggplot()`
 # `ggplot()` is the starting point of any plot. It sets up the initial plot with default settings that can be later customized with geoms, scales, theme settings and other specifications. `ggplot` usually used with a data source as an argument, and optionally, a set of aesthetics specified by @aes(). The data source is typically a DataFrame.
-#If a set of aesthetics is specified in the initial ggplot call, these aesthetics apply to all layers added to the plot, unless they are overridden in subsequent layers.
 
-ggplot(penguins, @aes(x=bill_length_mm, y=bill_depth_mm, color = species))+
+# If a set of aesthetics is specified in the initial ggplot call, these aesthetics apply to all layers added to the plot, unless they are overridden in subsequent layers.
+
+ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm, color = species)) +
     geom_point()
-    
+
 # ## `@aes()`
 # `aes()` is used to map variables in your data to visual properties (aesthetics) of the plot. These aesthetics can include things like position (x and y coordinates), color, shape, size, etc. Each aesthetic is a way of visualizing a variable or a statistical transformation of a variable.
+
 # Aesthetics are specified in the form aes(aesthetic = variable), where aesthetic is the name of the aesthetic, and variable is the column name in your data that you want to map to the aesthetic. The variable names do not need to be preceded by a colon.
 
 # Of note, TidierPlots.jl accepts multiple forms for aes specification, none of which is *exactly* the same as ggplot2.
@@ -32,11 +34,11 @@ ggplot(penguins, @aes(x=bill_length_mm, y=bill_depth_mm, color = species))+
 # Moving from general rules, to specific plots, let us first explore `geom_point()`
 
 # `geom_point()`
-# `geom_point` is used to create a scatter plot. It is typically used with aesthetics mapping variables to x and y positions, and optionally to other aesthetics like color, shape, and size. `geom_point` can be used to visualize the relationship between two continuous variables, or a continuous and a discrete variable. The following visuals features can be changed within `geom_point()`, shape, size, stroke, strokecolour, and alpha . 
+# `geom_point` is used to create a scatter plot. It is typically used with aesthetics mapping variables to x and y positions, and optionally to other aesthetics like color, shape, and size. `geom_point` can be used to visualize the relationship between two continuous variables, or a continuous and a discrete variable. The following visuals features can be changed within `geom_point()`, shape, size, stroke, strokecolour, and alpha .
 
-ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm, color = species)) + 
-    geom_point( size = 20, 
-                stroke = 1, 
+ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm, color = species)) +
+    geom_point( size = 20,
+                stroke = 1,
                 strokecolor = "black",
                 alpha = 0.2) +
     labs(x = "Bill Length (mm)", y = "Bill Width (mm)") +
@@ -44,12 +46,12 @@ ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm, color = species)) +
     theme_minimal()
 
 # In the example above, a scatter plot is created with the variable bill_length_mm mapped to the x position, and bill_depth_mm mapped to the y position with color mapped to species. Supported optional arguements include:
-       # - size - this is the size of the marker
-       # - alpha (or transparency), is set to a value between 0 and 1. 
-       # - strokecolor is the stroke color around the marker. https://juliagraphics.github.io/Colors.jl/stable/namedcolors/ colors can be chosen from any name on this list
-       # - stroke this is the thickeness of the stroke around the marker
+# - size - this is the size of the marker
+# - alpha (or transparency), is set to a value between 0 and 1.
+# - strokecolor is the stroke color around the marker. https://juliagraphics.github.io/Colors.jl/stable/namedcolors/ colors can be chosen from any name on this list
+# - stroke this is the thickeness of the stroke around the marker
 
-# ## `lims`  
+# ## `lims`
 # `lims` allows the user to set the ranges for the x and y axises as shown in the example above.
 
 # ## `geom_bar`, `geom_col`, and `geom_histogram`
@@ -63,10 +65,11 @@ ggplot(data=penguins, @aes(x=species)) +
          # - position, when set to "dodge," bar charts will not stack
 
 
-ggplot(data=penguins, @aes(x = island, y=species)) + geom_col()
-
+ggplot(data=penguins, @aes(x = island, y=species)) +
+    geom_col()
+#-
 ggplot() +
-  geom_histogram(data=penguins, @aes(x=bill_length_mm))
+  geom_histogram(data=penguins, @aes(x = bill_length_mm))
 
 # In the first example, a bar plot is created with the variable CategoricalVar mapped to the x position, and the count of each category is represented by the height of the bars.
 
@@ -102,18 +105,18 @@ ggplot()+
 
 # In this example, a boxplot is created where different island of penguins are mapped to the x position, and the bill length is mapped to the y position. Finally, the each species will be mapped to a different color
 
-# geom_boxplot supported optinal arguements currently include:  
+# geom_boxplot supported optinal arguements currently include:
        # - color - if used within the aes() with a categorical variable it will make each category a different color as shown above. When used outside of the aes() and selected with a color, it will make each boxplot that color.
        # - alpha - transaparency as above, used outside of the aes()
 
 # ## `geom_violin`
 # `geom_violin`  creates a violin plot, which is a combination of a boxplot and a kernel density plot.
 
-  ggplot(penguins, @aes(x=species, y=bill_depth_mm)) + 
+ggplot(penguins, @aes(x = species, y = bill_depth_mm)) +
     geom_violin()
 
 # In this example, a violin plot is created where different species of penguins are mapped to the x position, and the bill depth is mapped to the y position. geom_violin does not currently support mapping a categorical variable to colors.
-    
+
 # ## `geom_tile`
 # The `geom_tile` creates a tile plot, also known as a heatmap.
 
@@ -132,10 +135,10 @@ ggplot(df_tile, @aes(x = X, y = Y, z = Value)) +
 # ## `scale_x_log10`,  `scale_y_log10`
 # `scale_x_log10` and `scale_y_log10` apply a base 10 logarithmic transformation to the x and y axes, respectively.
 
-ggplot(penguins, @aes(x=body_mass_g, y=bill_length_mm)) + 
-  geom_point() +
-  scale_x_log10()
-  
+ggplot(penguins, @aes(x = body_mass_g, y = bill_length_mm)) +
+    geom_point() +
+    scale_x_log10()
+
 # In this example, a scatter plot is created where the body mass of penguins is mapped to the x position and the bill length to the y position. A base 10 logarithmic transformation is then applied to the x-axis.
 
 # ## `scale_x_log2`, `scale_y_log2`, `scale_x_log`, `scale_y_log`
@@ -150,7 +153,7 @@ ggplot(penguins, @aes(x=body_mass_g, y=bill_length_mm)) +
 # ## `scale_x_reverse`, `scale_y_reverse`
 # `scale_x_reverse` and `scale_y_reverse`  reverse the direction of the x and y axes, respectively.
 
-ggplot(penguins, @aes(x=body_mass_g, y=bill_length_mm, color = species)) + 
+ggplot(penguins, @aes(x = body_mass_g, y = bill_length_mm, color = species)) +
    geom_point() +
    scale_y_reverse() +
    theme_minimal()
@@ -160,11 +163,11 @@ ggplot(penguins, @aes(x=body_mass_g, y=bill_length_mm, color = species)) +
 # ## `scale_x_sqrt`, `scale_y_sqrt`
 #  `scale_x_sqrt` and `scale_y_sqrt`  apply a square root transformation to the x and y axes, respectively.
 
-ggplot(penguins, @aes(x=body_mass_g, y=bill_length_mm, color = species)) + 
+ggplot(penguins, @aes(x = body_mass_g, y = bill_length_mm, color = species)) +
    geom_point() +
    scale_x_sqrt() +
    theme_minimal()
-   
+
 # In this example, a scatter plot is created where the body mass of penguins is mapped to the x position and the bill length to the y position. A square root transformation is then applied to the x-axis
 
 # ## `geom_errorbar`

--- a/docs/examples/UserGuide/supported_functions.jl
+++ b/docs/examples/UserGuide/supported_functions.jl
@@ -3,8 +3,8 @@ using DataFrames
 using PalmerPenguins
 using CairoMakie
 
-# ## @geom_bar, @labs
+# ## geom_bar, labs
 penguins = dropmissing(DataFrame(PalmerPenguins.load()))
-ggplot(data = penguins) + 
+ggplot(data = penguins) +
     geom_bar(@aes(x = species)) +
     labs(x = "Species")

--- a/docs/genfiles.jl
+++ b/docs/genfiles.jl
@@ -23,6 +23,6 @@ srcsfiles = getfiles()
 for (d, paths) in (("tutorial", srcsfiles),)
     for p in paths
     Literate.markdown(get_example_path(p), joinpath(OUTPUT, dirname(p));
-            documenter=true)
+            documenter=true, mdstrings=true)
     end
 end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,6 +38,7 @@ Geoms:
 - `geom_smooth`
 - `geom_errorbar`
 - `geom_path`, `geom_line`, and `geom_step`
+- `geom_vline` and `geom_hline`
 - `geom_bar`, `geom_col`, and `geom_histogram`
 - `geom_boxplot` and `geom_violin`
 - `geom_contour` and `geom_tile`
@@ -99,8 +100,8 @@ using PalmerPenguins
 
 penguins = dropmissing(DataFrame(PalmerPenguins.load()))
 
-@ggplot(data = penguins) + 
-    @geom_bar(aes(x = species)) +
-    @labs(x = "Species")
+ggplot(data = penguins) + 
+    geom_bar(@aes(x = species)) +
+    labs(x = "Species")
 ```
 ![](assets/example_col.png)

--- a/src/aes.jl
+++ b/src/aes.jl
@@ -1,3 +1,10 @@
+"""
+    aes(args...; kwargs...)
+
+# Details
+
+TBD
+"""
 function aes(args...; kwargs...)
     col_transforms = Dict()
     aes_args = Symbol[]
@@ -26,7 +33,7 @@ function aes(args...; kwargs...)
             push!(aes_kwargs, String(k) => Symbol(v))
         end
     end
-        
+
     return Aesthetics(
             aes_args,
             aes_kwargs,
@@ -39,14 +46,14 @@ macro aes(exprs...)
     for aes_ex in exprs
         if aes_ex isa Expr
             if aes_ex.args[2] isa Expr
-                
-                
+
+
             elseif aes_ex.args[2] isa QuoteNode
                 aes_dict[String(aes_ex.args[1])] = aes_ex.args[2].value
             elseif aes_ex.args[2] isa String
                 aes_dict[String(aes_ex.args[1])] = Symbol(aes_ex.args[2])
             else
-                aes_dict[String(aes_ex.args[1])] = aes_ex.args[2] 
+                aes_dict[String(aes_ex.args[1])] = aes_ex.args[2]
             end
         elseif aes_ex isa Symbol
             push!(positional, aes_ex)

--- a/src/geoms/geom_bar.jl
+++ b/src/geoms/geom_bar.jl
@@ -1,4 +1,4 @@
-function handle_position(aes_dict::Dict{String, Symbol}, 
+function handle_position(aes_dict::Dict{String, Symbol},
     args_dict::Dict{Any, Any}, required_aes::Vector{String}, plot_data::DataFrame)
     # handles defaults and grouping for geom_bar/col
 
@@ -79,78 +79,101 @@ end
 """
     geom_col(aes(...), ...)
     geom_col(plot::GGPlot, aes(...), ...)
-    
-    Represent data as bars. 
 
-    # Arguments
+Represent data as bars.
 
-    - plot::GGPlot (optional): a plot object to "add" this geom to
-    - `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
-    - `position::String`: "stack" (the default) or "dodge"
-    - `...`: options that are not mapped to a column (passed to Makie.BarPlot) 
+# Arguments
 
-    # Required Aesthetics
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `position::String`: "stack" (the default) or "dodge"
+- `...`: options that are not mapped to a column (passed to Makie.BarPlot)
 
-    - x
-    - y
+# Required Aesthetics
 
-    # Supported Optional Aesthetics
+- `x`
+- `y`
 
-    - alpha
-    - colour/color
-    - fill
-    - group
-    - linetype
-    - linewidth
+# Supported Optional Aesthetics
 
-    # Supported Options
+- alpha
+- colour/color
+- fill
+- group
+- linetype
+- linewidth
 
-    - alpha
-    - colour/color
-    - fill
-    - group
-    - linetype
-    - linewidth
+# Supported Options
+
+- alpha
+- colour/color
+- fill
+- group
+- linetype
+- linewidth
 
 """
 geom_col = geom_template("geom_col", ["x", "y"], :BarPlot; aes_function = handle_position)
+
 """
     geom_col(aes(...), ...)
     geom_col(plot::GGPlot, aes(...), ...)
-    
-    Represent data as bars. 
 
-    # Arguments
+Represent data as bars.
 
-    - plot::GGPlot (optional): a plot object to "add" this geom to
-    - `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
-    - `...`: options that are not mapped to a column (passed to Makie.BarPlot)
+# Arguments
 
-    # Required Aesthetics
+- plot::GGPlot (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.BarPlot)
 
-    - x OR y
+# Required Aesthetics
 
-    # Supported Optional Aesthetics (See aes() for specification options)
+- x OR y
 
-    - alpha
-    - colour/color
-    - fill
-    - group
-    - linetype
-    - linewidth
+# Supported Optional Aesthetics (See aes() for specification options)
 
-    # Supported Options
+- alpha
+- colour/color
+- fill
+- group
+- linetype
+- linewidth
 
-    - alpha::Float32
-    - position::String - "stack" (the default) or "dodge"
-    - colour/color
-    - fill
-    - group
-    - linetype
-    - linewidth
+# Supported Options
 
+- alpha::Float32
+- position::String - "stack" (the default) or "dodge"
+- colour/color
+- fill
+- group
+- linetype
+- linewidth
 """
 geom_bar = geom_template("geom_bar", String[], :BarPlot; aes_function = handle_position)
 
-geom_histogram = geom_template("geom_histogram", ["x"], :Hist)
+"""
+    geom_histogram(aes(...), ...)
+    geom_histogram(plot::GGPlot, aes(...), ...)
 
+Represents data as a histogram.
+
+# Arguments
+
+- plot::GGPlot (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Hist)
+
+# Required Aesthetics
+
+TBD
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
+geom_histogram = geom_template("geom_histogram", ["x"], :Hist)

--- a/src/geoms/geom_bar.jl
+++ b/src/geoms/geom_bar.jl
@@ -80,7 +80,7 @@ end
     geom_col(aes(...), ...)
     geom_col(plot::GGPlot, aes(...), ...)
 
-Represent data as bars.
+Represent data as columns.
 
 # Arguments
 
@@ -94,7 +94,7 @@ Represent data as bars.
 - `x`
 - `y`
 
-# Supported Optional Aesthetics
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 - alpha
 - colour/color
@@ -116,8 +116,8 @@ Represent data as bars.
 geom_col = geom_template("geom_col", ["x", "y"], :BarPlot; aes_function = handle_position)
 
 """
-    geom_col(aes(...), ...)
-    geom_col(plot::GGPlot, aes(...), ...)
+    geom_bar(aes(...), ...)
+    geom_bar(plot::GGPlot, aes(...), ...)
 
 Represent data as bars.
 
@@ -129,9 +129,9 @@ Represent data as bars.
 
 # Required Aesthetics
 
-- x OR y
+- `x` OR `y`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 - alpha
 - colour/color
@@ -142,8 +142,8 @@ Represent data as bars.
 
 # Supported Options
 
-- alpha::Float32
-- position::String - "stack" (the default) or "dodge"
+- alpha
+- position: "stack" (the default) or "dodge"
 - colour/color
 - fill
 - group
@@ -166,9 +166,9 @@ Represents data as a histogram.
 
 # Required Aesthetics
 
-TBD
+- `x`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 

--- a/src/geoms/geom_boxplot.jl
+++ b/src/geoms/geom_boxplot.jl
@@ -14,7 +14,7 @@ Compactly displays the distribution of continuous data.
 
 - `x` OR `y`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 

--- a/src/geoms/geom_boxplot.jl
+++ b/src/geoms/geom_boxplot.jl
@@ -1,1 +1,25 @@
+"""
+    geom_boxplot(aes(...), ...)
+    geom_boxplot(plot::GGPlot, aes(...), ...)
+
+Compactly displays the distribution of continuous data.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.BoxPlot)
+
+# Required Aesthetics
+
+- `x` OR `y`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
 geom_boxplot = geom_template("geom_boxplot", ["x", "y"], :BoxPlot)

--- a/src/geoms/geom_contour.jl
+++ b/src/geoms/geom_contour.jl
@@ -1,4 +1,4 @@
-function stat_density_2d(aes_dict::Dict{String, Symbol}, 
+function stat_density_2d(aes_dict::Dict{String, Symbol},
     args_dict, required_aes::Vector{String}, plot_data::DataFrame)
 
     new_required_aes = ["x", "y", "z"]
@@ -8,8 +8,57 @@ function stat_density_2d(aes_dict::Dict{String, Symbol},
     return (aes_dict, args_dict, new_required_aes, plot_data)
 end
 
+"""
+    geom_tile(aes(...), ...)
+    geom_tile(plot::GGPlot, aes(...), ...)
+
+Represents data as...
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Heatmap)
+
+# Required Aesthetics
+
+TBD
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
 geom_tile = geom_template("geom_tile", ["x", "y", "z"], :Heatmap)
-geom_contour = geom_template("geom_contour", ["x", "y"], :Contour; 
+
+"""
+    geom_contour(aes(...), ...)
+    geom_contour(plot::GGPlot, aes(...), ...)
+
+Represents a grid of data as smooth curves of a surface.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Contour)
+
+# Required Aesthetics
+
+TBD
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
+geom_contour = geom_template("geom_contour", ["x", "y"], :Contour;
     aes_function = stat_density_2d,
     column_transformations = Dict{Symbol, Pair{Vector{Symbol}, AesTransform}}(
         :x => [:x]=>discard,

--- a/src/geoms/geom_contour.jl
+++ b/src/geoms/geom_contour.jl
@@ -24,7 +24,7 @@ Represents data as...
 
 TBD
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 
@@ -50,7 +50,7 @@ Represents a grid of data as smooth curves of a surface.
 
 TBD
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 

--- a/src/geoms/geom_density.jl
+++ b/src/geoms/geom_density.jl
@@ -14,7 +14,7 @@ Represent data as a smooth density curve.
 
 - `x`
 
-# Supported Optional Aesthetics
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 - alpha
 - stroke

--- a/src/geoms/geom_density.jl
+++ b/src/geoms/geom_density.jl
@@ -1,28 +1,29 @@
 """
-    @geom_density(aes(...), ...)
-    
-    Represent data as a smooth density curve. 
+    geom_density(aes(...), ...)
+    geom_density(plot::GGPlot, aes(...), ...)
 
-    # Arguments
+Represent data as a smooth density curve.
 
-    - `aes(...)`: the names of the columns in the plot DataFrame and their corresponding aesthetic.
-    - `...`: options that are not mapped to a column 
+# Arguments
 
-    # Required Aesthetics
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame and their corresponding aesthetic.
+- `...`: options that are not mapped to a column (passed to Makie.Density)
 
-    - x
+# Required Aesthetics
 
-    # Supported Optional Aesthetics
+- `x`
 
-    - alpha
-    - stroke
-    - colour/color
+# Supported Optional Aesthetics
 
-    # Supported Options
+- alpha
+- stroke
+- colour/color
 
-    - alpha
-    - stroke
-    - colour/color
+# Supported Options
 
+- alpha
+- stroke
+- colour/color
 """
 geom_density = geom_template("geom_density", ["x"], :Density)

--- a/src/geoms/geom_errorbar.jl
+++ b/src/geoms/geom_errorbar.jl
@@ -1,15 +1,71 @@
+"""
+    geom_errorbar(aes(...), ...)
+    geom_errorbar(plot::GGPlot, aes(...), ...)
+
+Represents data as a vertical interval.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Rangebars)
+
+# Required Aesthetics
+
+TBD
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
+function geom_errorbar end
+
 function geom_errorbar(args...; kwargs...)
     aes_dict, args_dict, transforms = extract_aes(args, kwargs)
 
     args_dict["geom_name"] = "geom_errorbar"
-    
-    return build_geom(aes_dict, args_dict, 
+
+    return build_geom(aes_dict, args_dict,
         ["x", "ymin", "ymax"], # required aesthetics
         :Rangebars, # function for visual layer
         do_nothing,
         transforms;
-        special_aes = Dict("width" => "whiskerwidth")) 
+        special_aes = Dict("width" => "whiskerwidth"))
 end
+
+function geom_errorbar(plot::GGPlot, args...; kwargs...)
+    return plot + geom_errorbar(args..., kwargs...)
+end
+
+"""
+    geom_errorbarh(aes(...), ...)
+    geom_errorbarh(plot::GGPlot, aes(...), ...)
+
+Represents data as a horizontal interval.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Rangebars)
+
+# Required Aesthetics
+
+TBD
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
+function geom_errorbarh end
 
 function geom_errorbarh(args...; kwargs...)
     aes_dict, args_dict, transforms = extract_aes(args, kwargs)
@@ -17,19 +73,15 @@ function geom_errorbarh(args...; kwargs...)
     args_dict["geom_name"] = "geom_errorbarh"
     args_dict["errorbar_direction"] = :x
 
-    return build_geom(aes_dict, args_dict, 
+    return build_geom(aes_dict, args_dict,
         ["y", "xmin", "xmax"], # required aesthetics
         :Rangebars, # function for visual layer
         do_nothing,
         transforms;
-        special_aes = Dict("width" => "whiskerwidth")) 
+        special_aes = Dict("width" => "whiskerwidth"))
 
 end
 
 function geom_errorbarh(plot::GGPlot, args...; kwargs...)
     return plot + geom_errorbarh(args..., kwargs...)
-end
-
-function geom_errorbar(plot::GGPlot, args...; kwargs...)
-    return plot + geom_errorbar(args..., kwargs...)
 end

--- a/src/geoms/geom_errorbar.jl
+++ b/src/geoms/geom_errorbar.jl
@@ -14,7 +14,7 @@ Represents data as a vertical interval.
 
 TBD
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 
@@ -57,7 +57,7 @@ Represents data as a horizontal interval.
 
 TBD
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 

--- a/src/geoms/geom_hvline.jl
+++ b/src/geoms/geom_hvline.jl
@@ -14,7 +14,7 @@ Plot a horizontal line at the given y-intercept.
 
 - `yintercept`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 
@@ -57,7 +57,7 @@ Plot a vertical line at the given x-intercept.
 
 - `xintercept`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 

--- a/src/geoms/geom_hvline.jl
+++ b/src/geoms/geom_hvline.jl
@@ -1,3 +1,29 @@
+"""
+    geom_hline(aes(...), ...)
+    geom_hline(plot::GGPlot, aes(...), ...)
+
+Plot a horizontal line at the given y-intercept.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.HLines)
+
+# Required Aesthetics
+
+- `yintercept`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
+function geom_hline end
+
 function geom_hline(args...; kwargs...)
     aes_dict, args_dict, transforms = extract_aes(args, kwargs)
 
@@ -14,6 +40,32 @@ function geom_hline(args...; kwargs...)
         do_nothing,
         transforms) # function for visual layer
 end
+
+"""
+    geom_vline(aes(...), ...)
+    geom_vline(plot::GGPlot, aes(...), ...)
+
+Plot a vertical line at the given x-intercept.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.XXXXX)
+
+# Required Aesthetics
+
+- `xintercept`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
+function geom_vline end
 
 function geom_vline(args...; kwargs...)
     aes_dict, args_dict, transforms = extract_aes(args, kwargs)

--- a/src/geoms/geom_path.jl
+++ b/src/geoms/geom_path.jl
@@ -1,3 +1,80 @@
+"""
+    geom_line(aes(...), ...)
+    geom_line(plot::GGPlot, aes(...), ...)
+
+Represents data as connected points in the order of the variable on the x-axis.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Lines)
+
+# Required Aesthetics
+
+- `x`
+- `y`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
 geom_line = geom_template("geom_line", ["x", "y"], :Lines)
+
+"""
+    geom_step(aes(...), ...)
+    geom_step(plot::GGPlot, aes(...), ...)
+
+Represents data as a stairstep plot.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Stairs)
+
+# Required Aesthetics
+
+- `x`
+- `y`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
 geom_step = geom_template("geom_step", ["x", "y"], :Stairs)
+
+"""
+    geom_path(aes(...), ...)
+    geom_path(plot::GGPlot, aes(...), ...)
+
+Represents data as connected points in the order in which they appear in the data.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Lines)
+
+# Required Aesthetics
+
+- `x`
+- `y`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
 geom_path = geom_template("geom_path", ["x", "y"], :Lines)

--- a/src/geoms/geom_path.jl
+++ b/src/geoms/geom_path.jl
@@ -15,7 +15,7 @@ Represents data as connected points in the order of the variable on the x-axis.
 - `x`
 - `y`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 
@@ -42,7 +42,7 @@ Represents data as a stairstep plot.
 - `x`
 - `y`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 
@@ -69,7 +69,7 @@ Represents data as connected points in the order in which they appear in the dat
 - `x`
 - `y`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 

--- a/src/geoms/geom_point.jl
+++ b/src/geoms/geom_point.jl
@@ -1,48 +1,30 @@
 """
-    # Points
+    geom_point(aes(...), ...)
+    geom_point(plot::GGPlot, aes(...), ...)
 
-    The point geom is used to create scatterplots. The scatterplot is most
-    useful for displaying the relationship between two continuous variables.
-    It can be used to compare one continuous and one categorical variable, or
-    two categorical variables, but a variation like `geom_jitter()`,
-    `geom_count()`, or `geom_bin_2d()` is usually more
-    appropriate. A _bubblechart_ is a scatterplot with a third variable
-    mapped to the size of points.
+Represents data as pairs of (x, y) points.
 
-    ## Usage
+# Arguments
 
-    geom_point(
-        plot::GGPlot,
-        data::DataFrame,
-        mapping::Aesthetics,
-        ... 
-    )
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Scatter)
 
-    ## Arguments
+# Required Aesthetics
 
-    All arguments are optional. If `data` and `mapping` are not specified, they will inherit from the GGPlot.
+- `x`
+- `y`
 
-    - `plot:` A GGPlot to modify 
-    - `data:` A DataFrame containing the data to be plotted.
-    - `mapping:` the names of the columns in the plot DataFrame that will be used to decide where the points are plotted. Create with the `aes` function.
-    - `...`: options that are not mapped to a column. Pass supported aesthetics here to fix them to a specific value. 
+# Supported Optional Aesthetics (See aes() for specification options)
 
-    ## Aesthetics (Required Aesthetics are in **bold**)
+- size
+- alpha
+- stroke
+- shape
+- colour/color
 
-    - **x**
-    - **y**
-    - size
-    - alpha
-    - stroke
-    - shape
-    - colour/color
+# Supported Options
 
-    ## Examples
-
-    ```
-    ggplot(mtcars, @aes(x = WT, y = MPG)) + 
-        geom_point()
-    ```
-    ![](src/assets/geom_point1.png)
+TBD
 """
 geom_point = geom_template("geom_point", ["x", "y"], :Scatter)

--- a/src/geoms/geom_point.jl
+++ b/src/geoms/geom_point.jl
@@ -15,7 +15,7 @@ Represents data as pairs of (x, y) points.
 - `x`
 - `y`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 - size
 - alpha

--- a/src/geoms/geom_smooth.jl
+++ b/src/geoms/geom_smooth.jl
@@ -15,7 +15,7 @@ Represent data as a smoothed or linear fit.
 - `x`
 - `y`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 - alpha
 - colour/color

--- a/src/geoms/geom_smooth.jl
+++ b/src/geoms/geom_smooth.jl
@@ -1,30 +1,30 @@
 """
     geom_smooth(aes(...), ...)
     geom_smooth(plot::GGPlot, aes(...), ...)
-    
-    Represent data as a smoothed or linear fit. 
 
-    # Arguments
+Represent data as a smoothed or linear fit.
 
-    - `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
-    - `...`: options that are not mapped to a column 
+# Arguments
 
-    # Required Aesthetics
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Lines)
 
-    - x
-    - y
+# Required Aesthetics
 
-    # Supported Optional Aesthetics
+- `x`
+- `y`
 
-    - alpha
-    - colour/color
+# Supported Optional Aesthetics (See aes() for specification options)
 
-    # Supported Options
+- alpha
+- colour/color
 
-    - method: "smooth" (loess fit) or "lm" (linear fit)
-    - alpha
-    - colour/color
+# Supported Options
 
+- method: "smooth" (loess fit) or "lm" (linear fit)
+- alpha
+- colour/color
 """
 function geom_smooth(plot::GGPlot, args...; kwargs...)
     return plot + geom_smooth(args...; kwargs...)
@@ -36,30 +36,30 @@ function geom_smooth(args...; kwargs...)
 
     if haskey(args_dict, "method")
         if args_dict["method"] == "lm"
-            return [build_geom(aes_dict, 
-                        args_dict, 
+            return [build_geom(aes_dict,
+                        args_dict,
                         ["x", "y"],
-                        :Lines, 
+                        :Lines,
                         stat_linear,
                         transforms),
                     build_geom(aes_dict,
-                        args_dict, 
+                        args_dict,
                         ["x", "lower", "upper"],
-                        :Band, 
+                        :Band,
                         stat_linear,
                         transforms)]
         end
     end
 
-    return build_geom(aes_dict, 
-                      args_dict, 
+    return build_geom(aes_dict,
+                      args_dict,
                       ["x", "y"],
-                      :Lines, 
+                      :Lines,
                       stat_loess,
                       transforms)
 end
 
-function stat_loess(aes_dict::Dict{String, Symbol}, 
+function stat_loess(aes_dict::Dict{String, Symbol},
     args_dict::Dict{String, Any}, required_aes::Vector{String}, plot_data::DataFrame)
 
     x = plot_data[!, aes_dict["x"]]
@@ -71,13 +71,13 @@ function stat_loess(aes_dict::Dict{String, Symbol},
 
     return_data = DataFrame(
         String(aes_dict["x"]) => x̂,
-        String(aes_dict["y"]) => ŷ 
+        String(aes_dict["y"]) => ŷ
     )
 
     return (aes_dict, args_dict, required_aes, return_data)
 end
 
-function stat_linear(aes_dict::Dict{String, Symbol}, 
+function stat_linear(aes_dict::Dict{String, Symbol},
     args_dict::Dict{String, Any}, required_aes::Vector{String}, plot_data::DataFrame)
 
     x = plot_data[!, aes_dict["x"]]
@@ -94,7 +94,7 @@ function stat_linear(aes_dict::Dict{String, Symbol},
     lin_model = GLM.lm(add_intercept_column(x), y)
     x̂ = range(extrema(x)..., length = 100)
     pred = DataFrame(GLM.predict(lin_model, add_intercept_column(x̂); interval = :confidence))
-    
+
     aes_dict["upper"] = :upper
     aes_dict["lower"] = :lower
 

--- a/src/geoms/geom_text.jl
+++ b/src/geoms/geom_text.jl
@@ -16,7 +16,7 @@ Plot text on a graph.
 - `y`
 - `text`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 
@@ -45,7 +45,7 @@ Plot text on a graph.
 - `y`
 - `text`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 

--- a/src/geoms/geom_text.jl
+++ b/src/geoms/geom_text.jl
@@ -1,4 +1,57 @@
-geom_text = geom_template("geom_text", ["x", "y"], :Text; 
+"""
+    geom_text(aes(...), ...)
+    geom_text(plot::GGPlot, aes(...), ...)
+
+Plot text on a graph.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Text)
+
+# Required Aesthetics
+
+- `x`
+- `y`
+- `text`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
+geom_text = geom_template("geom_text", ["x", "y"], :Text;
     column_transformations = Dict{Symbol, Pair{Vector{Symbol}, AesTransform}}(:text => [:text]=>verbatim))
-geom_label = geom_template("geom_label", ["x", "y"], :Text; 
+
+"""
+    geom_label(aes(...), ...)
+    geom_label(plot::GGPlot, aes(...), ...)
+
+Plot text on a graph.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Text)
+
+# Required Aesthetics
+
+- `x`
+- `y`
+- `text`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
+geom_label = geom_template("geom_label", ["x", "y"], :Text;
     column_transformations = Dict{Symbol, Pair{Vector{Symbol}, AesTransform}}(:text => [:text]=>verbatim))

--- a/src/geoms/geom_violin.jl
+++ b/src/geoms/geom_violin.jl
@@ -1,1 +1,26 @@
+"""
+    geom_(aes(...), ...)
+    geom_(plot::GGPlot, aes(...), ...)
+
+Represents data as a violin plot.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to "add" this geom to
+- `aes(...)`: the names of the columns in the plot DataFrame that will be used to decide where the points are plotted.
+- `...`: options that are not mapped to a column (passed to Makie.Violin)
+
+# Required Aesthetics
+
+- `x`
+- `y`
+
+# Supported Optional Aesthetics (See aes() for specification options)
+
+TBD
+
+# Supported Options
+
+TBD
+"""
 geom_violin = geom_template("geom_violin", ["x", "y"], :Violin)

--- a/src/geoms/geom_violin.jl
+++ b/src/geoms/geom_violin.jl
@@ -15,7 +15,7 @@ Represents data as a violin plot.
 - `x`
 - `y`
 
-# Supported Optional Aesthetics (See aes() for specification options)
+# Supported Optional Aesthetics (See [`aes`](@ref) for specification options)
 
 TBD
 


### PR DESCRIPTION
- Added doc strings for all geoms with a similar format
- removed outdated references to `@ggplot` and `@geom_*`
- enabled the use of md strings in literate docs (see https://fredrikekre.github.io/Literate.jl/v2/fileformat/#Syntax)
- updated the contributor's guide for adding examples and building docs locally

Many of the docs for geoms are still missing info about required aesthics, optional aesthetics, and supported options. I am planning to add those in the next few days as I become more familiar with the code base. I'm hoping this PR can be left open until I finish updating all the doc strings.

One other thing that I noticed is that previously the doc string contents were all indented 4 spaces which treated all the contents as being within a code block. I'm not sure if that was intentional, but I have removed the indent.