### PR TITLE
Pass all arguments on to Makie

### DIFF
--- a/src/TidierPlots.jl
+++ b/src/TidierPlots.jl
@@ -26,6 +26,7 @@ using KernelDensity
 
 include("structs.jl")
 
+include("attributes.jl")
 include("addplots.jl")
 include("aes.jl")
 include("aes_ops.jl")
@@ -76,7 +77,7 @@ export geom_point
 export geom_path
 export geom_line
 export geom_step
-export geom_smooth 
+export geom_smooth
 export geom_errorbar
 export geom_errorbarh
 export geom_violin
@@ -89,14 +90,14 @@ export geom_density
 export geom_hline
 export geom_vline
 
-# scales 
+# scales
 
 export labs, lims, c
 #export facet_wrap, facet_grid
 export scale_x_continuous, scale_y_continuous
-export scale_x_log10, scale_y_log10, scale_x_log2, scale_y_log2, scale_x_log, scale_y_log  
-export scale_x_logit, scale_y_logit  
-export scale_x_pseudolog10, scale_y_pseudolog10, scale_x_Symlog10, scale_y_Symlog10 
+export scale_x_log10, scale_y_log10, scale_x_log2, scale_y_log2, scale_x_log, scale_y_log
+export scale_x_logit, scale_y_logit
+export scale_x_pseudolog10, scale_y_pseudolog10, scale_x_Symlog10, scale_y_Symlog10
 export scale_x_reverse, scale_y_reverse, scale_x_sqrt, scale_y_sqrt
 export scale_colour_continuous, scale_colour_discrete, scale_colour_manual, scale_colour_binned
 export scale_color_continuous, scale_color_discrete, scale_color_manual, scale_color_binned

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1,0 +1,197 @@
+const _makie_expected_type = Dict{String, Type}(
+    # Generic Attributes
+    "depth_shift" => Float32,
+    "fxaa" => Bool,
+    "inspectable" => Bool,
+    "model" => Any,
+    "overdraw" => Bool,
+    "space" => Symbol,
+    "transparency" => Bool,
+    "visible" => Bool,
+
+    # Color Attributes
+    "alpha" => Real,
+    "color" => Any,
+    "colormap" => Symbol,
+    "colorrange" => Tuple{<:Real, <:Real},
+    "colorscale" => Function,
+    "highclip" => Any,
+    "lowclip" => Any,
+    "nan_color" => Any,
+
+    # Line Attributes
+    "linestyle" => Symbol,
+    "linewidth" => Real,
+    "step" => Symbol,
+
+    # Stroke Attributes
+    "strokecolor" => Symbol,
+    "strokewidth" => Real,
+    "strokearound" => Bool,
+
+    # Marker Attributes
+    "marker" => Symbol,
+    "markersize" => Real,
+    "markerspace" => Symbol,
+    "glowwidth" => Real,
+    "glowcolor" => Symbol,
+    "transform_marker" => Bool,
+
+    # Label Attributes
+    "label_color" => Symbol,
+    "label_font" => Symbol,
+    "label_offset" => Real,
+    "label_rotation" => Real,
+    "label_size" => Real,
+
+    # Text Attributes
+    "align" => Any,
+    "font" => Any,
+    "fontsize" => Real,
+    "justification" => Any,
+    "text" => Any,
+    "word_wrap_width" => Real,
+
+    # Transformations
+    "direction" => Symbol,
+    "flip" => Bool,
+    "orientation" => Symbol,
+    "rotation" => Real,
+
+    # BoxPlot/Violin Specific
+    "weights" => Any,
+    "side" => Symbol,
+    "show_notch" => Bool,
+    "notchwidth" => Real,
+    "show_median" => Bool,
+    "range" => Real,
+    "whiskerwidth" => Real,
+    "show_outliers" => Bool,
+
+    # Density Specific
+    "npoints" => Integer,
+
+    # HeatMap Specific
+    "interpolate" => Bool,
+
+    # Hist Specific
+    "normalization" => Symbol,
+    "bins" => Integer,
+
+    # HLines and VLines Specific
+    "xmin" => Real,
+    "xmax" => Real,
+    "ymin" => Real,
+    "ymax" => Real,
+);
+
+"""
+    MakieExpectedTypeDict <: AbstractDict{String, Type}
+
+A dictionary defining the expected types for Makie attributes with the default value `Any`.
+
+The singleton type is [`makie_expected_type`](@ref).
+
+# Examples
+
+```julia-repl
+julia> makie_expected_type("marker")
+Symbol
+
+julia> makie_expected_type("unknown_attr")
+Any
+
+julia> special_aes = Dict("unknown_attr" => Float64);
+
+julia> new_mapping = merge(makie_expected_type, special_aes);
+
+julia> new_mapping("unknown_attr")
+Float64
+
+julia> makie_expected_type("unknown_attr")
+Any
+```
+"""
+struct MakieExpectedTypeDict <: AbstractDict{String, Type}
+    dict::AbstractDict{String, Type}
+end
+
+Base.keys(d::MakieExpectedTypeDict) = keys(d.dict)
+Base.values(d::MakieExpectedTypeDict) = values(d.dict)
+Base.iterate(d::MakieExpectedTypeDict, state=1) = iterate(d.dict, state)
+Base.length(d::MakieExpectedTypeDict) = length(d.dict)
+Base.get(d::MakieExpectedTypeDict, key, default=Any) = get(d.dict, key, default)
+Base.getindex(d::MakieExpectedTypeDict, key) = get(d.dict, key, Any)
+
+(d::MakieExpectedTypeDict)(key::String) = d[key]
+
+function Base.merge(d::MakieExpectedTypeDict, others::AbstractDict{String, Type}...)
+    new_dict = merge(d.dict, others...)
+    return MakieExpectedTypeDict(new_dict)
+end
+
+"""
+    makie_expected_type
+
+The singleton instance of type [`MakieExpectedTypeDict`](@ref). b
+"""
+const makie_expected_type = MakieExpectedTypeDict(_makie_expected_type)
+
+
+
+const _ggplot_to_makie_attributes = Dict{String, String}(
+    "colour" => "color",
+    "shape" => "marker",
+    "size" => "markersize",
+    "stroke" => "strokewidth",
+    "strokecolour" => "strokecolor",
+    "linetype" => "linestyle",
+    "glow" => "glowwidth",
+    "glowcolour" => "glowcolor",
+    "errorbar_direction" => "direction",
+    "label" => "text",
+    "palette" => "colormap"
+)
+
+"""
+    GGPlotToMakieAttributeDict <: AbstractDict{String, String}
+
+A dictionary defining translations from GGPlot attributes to Makie attributes. Default value
+is just the key.
+
+The singleton instance is [`ggplot_to_makie_attribute`](@ref).
+
+# Examples
+
+```julia-repl
+julia> ggplot_to_makie_attribute["colour"]
+"color"
+
+julia> ggplot_to_makie_attribute["orientation"]
+"orientation"
+```
+"""
+struct GGPlotToMakieAttributeDict <: AbstractDict{String, String}
+    dict::AbstractDict{String, String}
+end
+
+Base.keys(d::GGPlotToMakieAttributeDict) = keys(d.dict)
+Base.values(d::GGPlotToMakieAttributeDict) = values(d.dict)
+Base.iterate(d::GGPlotToMakieAttributeDict, state=1) = iterate(d.dict, state)
+Base.length(d::GGPlotToMakieAttributeDict) = length(d.dict)
+Base.get(d::GGPlotToMakieAttributeDict, key, default=key) = get(d.dict, key, default)
+Base.getindex(d::GGPlotToMakieAttributeDict, key) = get(d.dict, key, key)
+
+(d::GGPlotToMakieAttributeDict)(key::String) = d[key]
+
+function Base.merge(d::GGPlotToMakieAttributeDict, others::AbstractDict{String, String}...)
+    new_dict = merge(d.dict, others...)
+    return GGPlotToMakieAttributeDict(new_dict)
+end
+
+"""
+    ggplot_to_makie_attribute
+
+The singleton instance of type [`GGPlotToMakieAttributeDict`](@ref).
+"""
+const ggplot_to_makie_attribute = GGPlotToMakieAttributeDict(_ggplot_to_makie_attributes)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1,3 +1,18 @@
+const _ggplot_to_makie = Dict{String, String}(
+    "colour" => "color",
+    "shape" => "marker",
+    "size" => "markersize",
+    "stroke" => "strokewidth",
+    "strokecolour" => "strokecolor",
+    "linetype" => "linestyle",
+    "glow" => "glowwidth",
+    "glowcolour" => "glowcolor",
+    "errorbar_direction" => "direction",
+    "label" => "text",
+    "palette" => "colormap"
+);
+
+
 const _makie_expected_type = Dict{String, Type}(
     # Generic Attributes
     "depth_shift" => Float32,
@@ -84,114 +99,3 @@ const _makie_expected_type = Dict{String, Type}(
     "ymin" => Real,
     "ymax" => Real,
 );
-
-"""
-    MakieExpectedTypeDict <: AbstractDict{String, Type}
-
-A dictionary defining the expected types for Makie attributes with the default value `Any`.
-
-The singleton type is [`makie_expected_type`](@ref).
-
-# Examples
-
-```julia-repl
-julia> makie_expected_type("marker")
-Symbol
-
-julia> makie_expected_type("unknown_attr")
-Any
-
-julia> special_aes = Dict("unknown_attr" => Float64);
-
-julia> new_mapping = merge(makie_expected_type, special_aes);
-
-julia> new_mapping("unknown_attr")
-Float64
-
-julia> makie_expected_type("unknown_attr")
-Any
-```
-"""
-struct MakieExpectedTypeDict <: AbstractDict{String, Type}
-    dict::AbstractDict{String, Type}
-end
-
-Base.keys(d::MakieExpectedTypeDict) = keys(d.dict)
-Base.values(d::MakieExpectedTypeDict) = values(d.dict)
-Base.iterate(d::MakieExpectedTypeDict, state=1) = iterate(d.dict, state)
-Base.length(d::MakieExpectedTypeDict) = length(d.dict)
-Base.get(d::MakieExpectedTypeDict, key, default=Any) = get(d.dict, key, default)
-Base.getindex(d::MakieExpectedTypeDict, key) = get(d.dict, key, Any)
-
-(d::MakieExpectedTypeDict)(key::String) = d[key]
-
-function Base.merge(d::MakieExpectedTypeDict, others::AbstractDict{String, Type}...)
-    new_dict = merge(d.dict, others...)
-    return MakieExpectedTypeDict(new_dict)
-end
-
-"""
-    makie_expected_type
-
-The singleton instance of type [`MakieExpectedTypeDict`](@ref). b
-"""
-const makie_expected_type = MakieExpectedTypeDict(_makie_expected_type)
-
-
-
-const _ggplot_to_makie_attributes = Dict{String, String}(
-    "colour" => "color",
-    "shape" => "marker",
-    "size" => "markersize",
-    "stroke" => "strokewidth",
-    "strokecolour" => "strokecolor",
-    "linetype" => "linestyle",
-    "glow" => "glowwidth",
-    "glowcolour" => "glowcolor",
-    "errorbar_direction" => "direction",
-    "label" => "text",
-    "palette" => "colormap"
-)
-
-"""
-    GGPlotToMakieAttributeDict <: AbstractDict{String, String}
-
-A dictionary defining translations from GGPlot attributes to Makie attributes. Default value
-is just the key.
-
-The singleton instance is [`ggplot_to_makie_attribute`](@ref).
-
-# Examples
-
-```julia-repl
-julia> ggplot_to_makie_attribute["colour"]
-"color"
-
-julia> ggplot_to_makie_attribute["orientation"]
-"orientation"
-```
-"""
-struct GGPlotToMakieAttributeDict <: AbstractDict{String, String}
-    dict::AbstractDict{String, String}
-end
-
-Base.keys(d::GGPlotToMakieAttributeDict) = keys(d.dict)
-Base.values(d::GGPlotToMakieAttributeDict) = values(d.dict)
-Base.iterate(d::GGPlotToMakieAttributeDict, state=1) = iterate(d.dict, state)
-Base.length(d::GGPlotToMakieAttributeDict) = length(d.dict)
-Base.get(d::GGPlotToMakieAttributeDict, key, default=key) = get(d.dict, key, default)
-Base.getindex(d::GGPlotToMakieAttributeDict, key) = get(d.dict, key, key)
-
-(d::GGPlotToMakieAttributeDict)(key::String) = d[key]
-
-function Base.merge(d::GGPlotToMakieAttributeDict, others::AbstractDict{String, String}...)
-    new_dict = merge(d.dict, others...)
-    return GGPlotToMakieAttributeDict(new_dict)
-end
-
-"""
-    ggplot_to_makie_attribute
-
-The singleton instance of type [`GGPlotToMakieAttributeDict`](@ref).
-"""
-const ggplot_to_makie_attribute = GGPlotToMakieAttributeDict(_ggplot_to_makie_attributes)

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -1,42 +1,6 @@
 import Makie.SpecApi
 
 function Makie.SpecApi.Axis(plot::GGPlot)
-     # translation dict for GGPlot term => Makie Term
-    # terms that aren't on this list won't be translated, just passed directly to Makie
-    ggplot_to_makie = Dict{String, String}(
-        "colour" => "color",
-        "shape" => "marker",
-        "size" => "markersize",
-        "stroke" => "strokewidth",
-        "strokecolour" => "strokecolor",
-        "linetype" => "linestyle",
-        "glow" => "glowwidth",
-        "glowcolour" => "glowcolor",
-        "errorbar_direction" => "direction",
-        "label" => "text",
-        "palette" => "colormap"
-    )
-
-    # What type does the Makie argument expect? 
-    # without a specified type here, arguments will pass "as is"
-    
-    expected_type = Dict{String, Type}(
-        # Symbol
-        "marker"        => Symbol,
-        "strokecolor"   => Symbol,
-        "glowcolor"     => Symbol,
-        "colormap"      => Symbol,
-        "yaxisposition" => Symbol,
-        "direction"     => Symbol,
-        # Float
-        "alpha"         => Float32,
-        "markersize"    => Float32,
-        "strokewidth"   => Float32,
-        "glowwidth"     => Float32,
-        # Integer
-        "bins"          => Int64
-    )
-
     plot_list = Makie.PlotSpec[]
     axis_options = Dict{Symbol, Any}()
 
@@ -48,24 +12,24 @@ function Makie.SpecApi.Axis(plot::GGPlot)
         aes_dict = merge(plot.default_aes, geom.aes)
 
         # apply function if required to edit the aes/args/data
-        aes_dict, args_dict, required_aes, plot_data = 
+        aes_dict, args_dict, required_aes, plot_data =
             geom.aes_function(aes_dict, geom.args, geom.required_aes, plot_data)
-        
+
         # make a master list of all possible accepted optional aesthetics and args
-        ggplot_to_makie_geom = merge(ggplot_to_makie, geom.special_aes)
-        
+        ggplot_to_makie_geom = merge(_ggplot_to_makie, geom.special_aes)
+
         # which aesthetics were given?
         given_aes = Dict{Symbol, PlottableData}()
 
         # inherit any unspecified column transforms
         col_transforms = merge(geom.column_transformations, plot.column_transformations)
-        
+
         aes_dict_makie = Dict{Symbol, Symbol}()
 
         for (aes_string, column_name) in aes_dict
             # the name of the aes is translated to the makie term if needed
-            aes = haskey(ggplot_to_makie_geom, aes_string) ? Symbol(ggplot_to_makie_geom[aes_string]) : Symbol(aes_string)
-            push!(aes_dict_makie, aes => column_name)
+            aes = get(ggplot_to_makie_geom, aes_string, aes_string)
+            push!(aes_dict_makie, Symbol(aes) => column_name)
         end
 
         for (aes, column_name) in aes_dict_makie
@@ -92,26 +56,13 @@ function Makie.SpecApi.Axis(plot::GGPlot)
             merge!(given_aes, plottable_data)
         end
 
-        # which ones were given as arguments? 
-
         args_dict_makie = Dict{Symbol, Any}()
 
         for (arg, value) in args_dict
-            if haskey(expected_type, arg)
-                try
-                    if haskey(ggplot_to_makie_geom, arg)
-                        args_dict_makie[Symbol(ggplot_to_makie_geom[arg])] = expected_type[arg](value)
-                    else
-                        args_dict_makie[Symbol(arg)] = expected_type[arg](value)
-                    end
-                catch
-                    ex_type = expected_type[arg]
-                    given_type = typeof(args_dict[arg])
-                    geom_name = geom.args["geom_name"]
-                    @error "Argument $arg in $geom_name given as type $given_type, 
-                            which cannot be converted to expected type $ex_type."
-                end
-            end
+            ex_type = get(_makie_expected_type, arg, Any)
+            converted_value = try_convert(ex_type, value, arg, geom.args["geom_name"])
+            makie_attr = get(ggplot_to_makie_geom, arg, arg)
+            args_dict_makie[Symbol(makie_attr)] = converted_value
         end
 
         required_aes_data = [p.makie_function(p.raw) for p in [given_aes[a] for a in Symbol.(required_aes)]]
@@ -121,36 +72,20 @@ function Makie.SpecApi.Axis(plot::GGPlot)
         kwargs = merge(args_dict_makie, Dict(optional_aes_data))
 
         # push completed PlotSpec (type, args, and kwargs) to the list of plots
-
         push!(plot_list, Makie.PlotSpec(args...; kwargs...))
     end
 
     # rename and correct types on all axis options
-
     for (arg, value) in plot.axis_options
-        if haskey(expected_type, arg)
-            value = expected_type[arg](value)
-        end
-
-        try
-            if haskey(ggplot_to_makie, arg)
-                axis_options[Symbol(ggplot_to_makie[arg])] = value
-            else
-                axis_options[Symbol(arg)] = value
-            end
-        catch
-            ex_type = expected_type[arg]
-            given_type = typeof(args_dict[arg])
-            @error "Argument $arg in ggplot() given as type $given_type, which cannot be converted to expected type $ex_type."
-        end
+        ex_type = get(_makie_expected_type, arg, Any)
+        converted_value = try_convert(ex_type, value, arg, "ggplot")
+        makie_attr = get(_ggplot_to_makie, arg, arg)
+        axis_options[Symbol(makie_attr)] = converted_value
     end
 
-    return length(axis_options) == 0 ? 
+    return length(axis_options) == 0 ?
         Makie.SpecApi.Axis(plots = plot_list) :
-        Makie.SpecApi.Axis(
-                plots = plot_list; 
-                axis_options...
-            )
+        Makie.SpecApi.Axis(plots = plot_list; axis_options...)
 end
 
 function draw_ggplot(plot::GGPlot)
@@ -165,4 +100,15 @@ end
 
 function draw_ggplot(plot_grid::GGPlotGrid)
     Makie.plot(plot_grid.grid)
+end
+
+function try_convert(T::Type, v::S, arg, fname) where {S}
+    try
+        retvalue = convert(T, v)
+        return retvalue
+    catch
+        msg = "Argument '$arg' in '$fname' has value '$v' and type '$S' which cannot be " *
+        "converted to the expected type '$T'."
+        throw(ArgumentError(msg))
+    end
 end

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -102,9 +102,11 @@ function draw_ggplot(plot_grid::GGPlotGrid)
     Makie.plot(plot_grid.grid)
 end
 
+try_convert(::Type{Any}, v, ::Any, ::Any) = v
+
 function try_convert(T::Type, v::S, arg, fname) where {S}
     try
-        retvalue = convert(T, v)
+        retvalue = T(v)
         return retvalue
     catch
         msg = "Argument '$arg' in '$fname' has value '$v' and type '$S' which cannot be " *


### PR DESCRIPTION
This will fix #83. Instead of using `haskey(dict, key)`, I used `get(dict, key, default)` to simplify the code and ensure that all arguments get passed on to Makie. For `ggplot_to_makie` dict, the default value is just whatever key is being passed in. For `expected_type` dict, the default value is `Any` which is a no-op conversion. To simplify the code more, I moved the `expected_type` dict and `ggplot_to_makie` dict to the `attributes.jl` file in case they need to be referenced in other files.

Examples

```julia
key = "colour"
get(ggplot_to_makie, key, key) # returns "color"
key = "some_attribute"
get(ggplot_to_makie, key, key) # returns "some_attribute"

key = "alpha"
get(expected_type, key, Any) # returns Real
key = "unknown_attr"
get(expected_type, key, Any) # returns Any
```