### PR TITLE
used - instead of , to remove compat curse

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ KernelDensity = "0.6"
 Loess = "0.6"
 Makie = "0.21"
 Reexport = "1.2"
-TidierData = "0.15, 1"
+TidierData = "0.15 - 1"
 julia = "1.9"
 
 [extras]


### PR DESCRIPTION
accidentally released v0.7.8 with tidierdata compat as a , not a - so it was not a range. this should actually absolve the issues.