### PR TITLE
Adding geom_density_2d and geom contour

### DIFF
--- a/src/TidierPlots.jl
+++ b/src/TidierPlots.jl
@@ -79,6 +79,7 @@ include("geoms/geom_rainclouds.jl")
 include("geoms/geom_text.jl")
 include("geoms/geom_tile.jl")
 include("geoms/geom_violin.jl")
+include("geoms/geom_density_2d.jl")
 
 # theming
 
@@ -114,6 +115,12 @@ export geom_density
 export geom_hline
 export geom_vline
 export geom_rainclouds
+export geom_contour
+export geom_contour_filled
+export geom_density_2d
+export geom_density_2d_filled
+export geom_density2d
+export geom_density2d_filled
 
 # facetting
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1,174 +1,188 @@
 const _legend_geom_elements = Dict{String,DataType}(
-    "geom_bar" => MarkerElement,
-    "geom_col" => MarkerElement,
-    "geom_histogram" => MarkerElement,
-    "geom_point" => MarkerElement,
-    "geom_path" => LineElement,
-    "geom_line" => LineElement,
-    "geom_step" => LineElement,
-    "geom_smooth" => LineElement,
-    "geom_errorbar" => LineElement,
-    "geom_errorbarh" => LineElement,
-    "geom_violin" => MarkerElement,
-    "geom_boxplot" => MarkerElement,
-    "geom_contour" => LineElement,
-    "geom_tile" => MarkerElement,
-    "geom_text" => MarkerElement,
-    "geom_label" => MarkerElement,
-    "geom_density" => MarkerElement,
-    "geom_hline" => LineElement,
-    "geom_vline" => LineElement
+  "geom_bar" => MarkerElement,
+  "geom_col" => MarkerElement,
+  "geom_histogram" => MarkerElement,
+  "geom_point" => MarkerElement,
+  "geom_path" => LineElement,
+  "geom_line" => LineElement,
+  "geom_step" => LineElement,
+  "geom_smooth" => LineElement,
+  "geom_errorbar" => LineElement,
+  "geom_errorbarh" => LineElement,
+  "geom_violin" => MarkerElement,
+  "geom_boxplot" => MarkerElement,
+  "geom_contour" => LineElement,
+  "geom_tile" => MarkerElement,
+  "geom_text" => MarkerElement,
+  "geom_label" => MarkerElement,
+  "geom_density" => MarkerElement,
+  "geom_hline" => LineElement,
+  "geom_vline" => LineElement,
+  "geom_contour_filled" => MarkerElement,
+  "geom_density_2d" => LineElement,
+  "geom_density_2d_filled" => MarkerElement,
+  "geom_density2d" => LineElement,
+  "geom_density2d_filled" => MarkerElement
 );
 
 const _legend_geom_symbols = Dict{String,Dict}(
-    "geom_bar" => Dict(:marker => :rect, :markersize => 12),
-    "geom_col" => Dict(:marker => :rect, :markersize => 12),
-    "geom_histogram" => Dict(:marker => :rect, :markersize => 12),
-    "geom_point" => Dict(:marker => :circle, :markersize => 12),
-    "geom_path" => Dict(:linestyle => nothing),
-    "geom_line" => Dict(:linestyle => nothing),
-    "geom_step" => Dict(:linestyle => nothing),
-    "geom_smooth" => Dict(:linestyle => nothing),
-    "geom_errorbar" => Dict(:linestyle => nothing),
-    "geom_errorbarh" => Dict(:linestyle => nothing),
-    "geom_violin" => Dict(:marker => :rect, :markersize => 12),
-    "geom_boxplot" => Dict(:marker => :rect, :markersize => 12),
-    "geom_contour" => Dict(:linestyle => nothing),
-    "geom_tile" => Dict(:marker => :rect, :markersize => 12),
-    "geom_text" => Dict(:marker => :x, :markersize => 12),
-    "geom_label" => Dict(:marker => :x, :markersize => 12),
-    "geom_density" => Dict(:marker => :rect, :markersize => 12),
-    "geom_hline" => Dict(:linestyle => nothing),
-    "geom_vline" => Dict(:linestyle => nothing),
-    "geom_rainclouds" => Dict(:marker => :rect, :markersize => 12)
+  "geom_bar" => Dict(:marker => :rect, :markersize => 12),
+  "geom_col" => Dict(:marker => :rect, :markersize => 12),
+  "geom_histogram" => Dict(:marker => :rect, :markersize => 12),
+  "geom_point" => Dict(:marker => :circle, :markersize => 12),
+  "geom_path" => Dict(:linestyle => nothing),
+  "geom_line" => Dict(:linestyle => nothing),
+  "geom_step" => Dict(:linestyle => nothing),
+  "geom_smooth" => Dict(:linestyle => nothing),
+  "geom_errorbar" => Dict(:linestyle => nothing),
+  "geom_errorbarh" => Dict(:linestyle => nothing),
+  "geom_violin" => Dict(:marker => :rect, :markersize => 12),
+  "geom_boxplot" => Dict(:marker => :rect, :markersize => 12),
+  "geom_contour" => Dict(:linestyle => nothing),
+  "geom_tile" => Dict(:marker => :rect, :markersize => 12),
+  "geom_text" => Dict(:marker => :x, :markersize => 12),
+  "geom_label" => Dict(:marker => :x, :markersize => 12),
+  "geom_density" => Dict(:marker => :rect, :markersize => 12),
+  "geom_hline" => Dict(:linestyle => nothing),
+  "geom_vline" => Dict(:linestyle => nothing),
+  "geom_rainclouds" => Dict(:marker => :rect, :markersize => 12),
+  "geom_contour_filled" => Dict(:marker => :rect, :markersize => 12),
+  "geom_density_2d" => Dict(:linestyle => nothing),
+  "geom_density_2d_filled" => Dict(:marker => :rect, :markersize => 12),
+  "geom_density2d" => Dict(:linestyle => nothing),
+  "geom_density2d_filled" => Dict(:marker => :rect, :markersize => 12)
 );
 
 const _ggplot_to_makie = Dict{Symbol,Symbol}(
-    :colour => :color,
-    :shape => :marker,
-    :size => :markersize,
-    :stroke => :strokewidth,
-    :strokecolour => :strokecolor,
-    :linetype => :linestyle,
-    :glow => :glowwidth,
-    :glowcolour => :glowcolor,
-    :errorbar_direction => :direction,
-    :palette => :colormap
+  :colour => :color,
+  :shape => :marker,
+  :size => :markersize,
+  :stroke => :strokewidth,
+  :strokecolour => :strokecolor,
+  :linetype => :linestyle,
+  :glow => :glowwidth,
+  :glowcolour => :glowcolor,
+  :errorbar_direction => :direction,
+  :palette => :colormap,
+  :breaks => :levels
 );
 
 
 const _makie_expected_type = Dict{String,Type}(
-    # Generic Attributes
-    "depth_shift" => Float32,
-    "fxaa" => Bool,
-    "inspectable" => Bool,
-    "model" => Any,
-    "overdraw" => Bool,
-    "space" => Symbol,
-    "transparency" => Bool,
-    "visible" => Bool,
+  # Generic Attributes
+  "depth_shift" => Float32,
+  "fxaa" => Bool,
+  "inspectable" => Bool,
+  "model" => Any,
+  "overdraw" => Bool,
+  "space" => Symbol,
+  "transparency" => Bool,
+  "visible" => Bool,
 
-    # Color Attributes
-    "alpha" => Real,
-    "color" => Any,
-    "colormap" => Symbol,
-    "colorrange" => Tuple{<:Real,<:Real},
-    "colorscale" => Function,
-    "highclip" => Any,
-    "lowclip" => Any,
-    "nan_color" => Any,
+  # Color Attributes
+  "alpha" => Real,
+  "color" => Any,
+  "colormap" => Symbol,
+  "colorrange" => Tuple{<:Real,<:Real},
+  "colorscale" => Function,
+  "highclip" => Any,
+  "lowclip" => Any,
+  "nan_color" => Any,
 
-    # Line Attributes
-    "linestyle" => Symbol,
-    "linewidth" => Real,
-    "step" => Symbol,
+  # Line Attributes
+  "linestyle" => Symbol,
+  "linewidth" => Real,
+  "step" => Symbol,
 
-    # Stroke Attributes
-    "strokecolor" => Symbol,
-    "strokewidth" => Real,
-    "strokearound" => Bool,
+  # Stroke Attributes
+  "strokecolor" => Symbol,
+  "strokewidth" => Real,
+  "strokearound" => Bool,
 
-    # Marker Attributes
-    "marker" => Any,
-    "markersize" => Real,
-    "markerspace" => Symbol,
-    "glowwidth" => Real,
-    "glowcolor" => Symbol,
-    "transform_marker" => Bool,
+  # Marker Attributes
+  "marker" => Any,
+  "markersize" => Real,
+  "markerspace" => Symbol,
+  "glowwidth" => Real,
+  "glowcolor" => Symbol,
+  "transform_marker" => Bool,
 
-    # Label Attributes
-    "label_color" => Symbol,
-    "label_font" => Symbol,
-    "label_offset" => Real,
-    "label_rotation" => Real,
-    "label_size" => Real,
+  # Label Attributes
+  "label_color" => Symbol,
+  "label_font" => Symbol,
+  "label_offset" => Real,
+  "label_rotation" => Real,
+  "label_size" => Real,
 
-    # Text Attributes
-    "align" => Any,
-    "font" => Any,
-    "fontsize" => Real,
-    "justification" => Any,
-    "text" => Any,
-    "word_wrap_width" => Real,
+  # Text Attributes
+  "align" => Any,
+  "font" => Any,
+  "fontsize" => Real,
+  "justification" => Any,
+  "text" => Any,
+  "word_wrap_width" => Real,
 
-    # Transformations
-    "direction" => Symbol,
-    "flip" => Bool,
-    "orientation" => Symbol,
-    "rotation" => Real,
+  # Transformations
+  "direction" => Symbol,
+  "flip" => Bool,
+  "orientation" => Symbol,
+  "rotation" => Real,
 
-    # BoxPlot/Violin Specific
-    "weights" => Any,
-    "side" => Symbol,
-    "show_notch" => Bool,
-    "notchwidth" => Real,
-    "show_median" => Bool,
-    "range" => Real,
-    "whiskerwidth" => Real,
-    "show_outliers" => Bool,
+  # BoxPlot/Violin Specific
+  "weights" => Any,
+  "side" => Symbol,
+  "show_notch" => Bool,
+  "notchwidth" => Real,
+  "show_median" => Bool,
+  "range" => Real,
+  "whiskerwidth" => Real,
+  "show_outliers" => Bool,
 
-    # Density Specific
-    "npoints" => Integer,
+  # Density Specific
+  "npoints" => Integer,
 
-    # HeatMap Specific
-    "interpolate" => Bool,
+  # HeatMap Specific
+  "interpolate" => Bool,
 
-    # Hist Specific
-    "normalization" => Symbol,
-    "bins" => Integer,
+  # Contour and 2D density Specific
+  "levels" => Real,
 
-    # HLines and VLines Specific
-    "xmin" => Real,
-    "xmax" => Real,
-    "ymin" => Real,
-    "ymax" => Real,
+  # Hist Specific
+  "normalization" => Symbol,
+  "bins" => Integer,
 
-    # Aes
-    "color" => Colors.RGBA,
-    "strokecolor" => Colors.RGBA,
-    "dodge" => Integer,
-    "stack" => Integer,
+  # HLines and VLines Specific
+  "xmin" => Real,
+  "xmax" => Real,
+  "ymin" => Real,
+  "ymax" => Real,
+
+  # Aes
+  "color" => Colors.RGBA,
+  "strokecolor" => Colors.RGBA,
+  "dodge" => Integer,
+  "stack" => Integer,
 );
 
 # options that are not meant to go to Makie
 # keep these in alphabetical order if making additions
 const _internal_geom_options = Symbol[
-    :data,
-    :geom_name,
-    :inherit_aes,
-    :lower,
-    :method,
-    :position,
-    :upper,
-    :x, :x1, :x2,
-    :xintercept,
-    :xmax,
-    :xmin,
-    :y, :y1, :y2,
-    :yintercept,
-    :ymax,
-    :ymin,
-    :group, :facet
+  :data,
+  :geom_name,
+  :inherit_aes,
+  :lower,
+  :method,
+  :position,
+  :upper,
+  :x, :x1, :x2,
+  :xintercept,
+  :xmax,
+  :xmin,
+  :y, :y1, :y2,
+  :yintercept,
+  :ymax,
+  :ymin,
+  :group, :facet
 ]
 
 # aesthetics that should not be treated as categorical variables

--- a/src/geoms/geom_density_2d.jl
+++ b/src/geoms/geom_density_2d.jl
@@ -1,0 +1,163 @@
+function stat_contour(
+  aes_dict,
+  args_dict,
+  required_aes::Vector{String},
+  plot_data::DataFrame,
+)
+  if !haskey(aes_dict, :x) || !haskey(aes_dict, :y)
+    ArgumentError("geom_density_2d requires x and y aesthetics")
+  end
+
+  x = plot_data[!, :x]
+  y = plot_data[!, :y]
+  if all(x .== y)
+    @warn "Equal x and y aesthetics detected. This may not be intended."
+  end
+  x_range = (minimum(x), maximum(x))
+  y_range = (minimum(y), maximum(y))
+  estimates_list = []
+
+  unique_groups = unique(plot_data[!, :group])
+  for group in unique_groups
+    group_indices = plot_data[!, :group] .== group
+    x_group = x[group_indices]
+    y_group = y[group_indices]
+    estimates = KernelDensity.kde((x_group, y_group); boundary=(x_range, y_range))
+    push!(estimates_list, (group, estimates))
+  end
+
+  x̂ = reduce(vcat, [repeat(estimates.x, length(estimates.y)) for (_, estimates) in estimates_list])
+  ŷ = reduce(vcat, [repeat(estimates.y, inner=length(estimates.x)) for (_, estimates) in estimates_list])
+  ẑ = reduce(vcat, [vec(estimates.density) for (_, estimates) in estimates_list])
+  group = reduce(vcat, [fill(group, length(estimates.x) * length(estimates.y)) for (group, estimates) in estimates_list])
+
+  return_data = DataFrame(
+    :x => x̂,
+    :y => ŷ,
+    :z => ẑ,
+    :group => group
+  )
+
+
+  if !haskey(aes_dict, :z)
+    push!(aes_dict, :z => :z => identity)
+  end
+  if "z" ∉ required_aes
+    push!(required_aes, "z")
+  end
+  return (aes_dict, args_dict, required_aes, return_data)
+end
+
+
+geom_density_2d = geom_template("geom_density_2d", ["x", "y"], :Contour;
+  grouping_aes=[:linestyle, :color, :colour],
+  post_function=stat_contour
+)
+
+geom_density2d = geom_density_2d
+
+geom_contour = geom_density_2d
+
+
+geom_density_2d_filled = geom_template("geom_density_2d_filled", ["x", "y"], :Contourf;
+  grouping_aes=[:color, :colour],
+  post_function=stat_contour
+)
+geom_density2d_filled = geom_density_2d_filled
+
+geom_contour_filled = geom_density_2d_filled
+
+
+"""
+    geom_density_2d(aes(...), ...)
+    geom_density_2d(plot::GGPlot, aes(...), ...)
+
+    geom_density2d(aes(...), ...)
+    geom_density2d(plot::GGPlot, aes(...), ...)
+
+    geom_contour(aes(...), ...)
+    geom_contour(plot::GGPlot, aes(...), ...)
+
+Represent data as a 2D density contour using 2D kernel density estimation.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to add this geom to
+- `aes(...)`: the names of the columns in the DataFrame that will be used in the mapping
+- `...`: options that are not mapped to a column (passed to Makie.Density)
+
+# Required Aesthetics
+
+- `x`
+- `y`
+
+# Optional Aesthetics (see [`aes`](@ref))
+
+- `color` / `colour`
+- `strokewidth` / `stroke`
+- `linestyle` / `linetype`
+- `alpha`
+- `group`
+
+# Optional Arguments
+
+- `breaks` / `levels`
+
+# Examples
+
+```julia
+ggplot(penguins, @aes(x=bill_length_mm, y=bill_depth_mm)) +
+    geom_density_2d()
+
+ggplot(penguins, @aes(x=bill_length_mm, y=bill_depth_mm)) +
+    geom_density_2d(color = :black, stroke = 2)
+```
+See also [`geom_contour_filled`](@ref) and [`geom_density_2d_filled`](@ref) for similar geoms.
+"""
+geom_density_2d, geom_density2d, geom_contour
+
+"""
+    geom_density_2d_filled(aes(...), ...)
+    geom_density_2d_filled(plot::GGPlot, aes(...), ...)
+
+    geom_density2d_filled(aes(...), ...)
+    geom_density2d_filled(plot::GGPlot, aes(...), ...)
+
+    geom_contour_filled(aes(...), ...)
+    geom_contour_filled(plot::GGPlot, aes(...), ...)
+
+Represent data as a filled 2D density contour using 2D kernel density estimation.
+
+# Arguments
+
+- `plot::GGPlot` (optional): a plot object to add this geom to
+- `aes(...)`: the names of the columns in the DataFrame that will be used in the mapping
+- `...`: options that are not mapped to a column (passed to Makie.Density)
+
+# Required Aesthetics
+
+- `x`
+- `y`
+
+# Optional Aesthetics (see [`aes`](@ref))
+
+- `color` / `colour`
+- `alpha`
+- `group`
+
+# Optional Arguments
+
+- `breaks` / `levels`
+
+# Examples
+
+```julia
+ggplot(penguins, @aes(x=bill_length_mm, y=bill_depth_mm)) +
+    geom_density_2d_filled()
+
+ggplot(penguins, @aes(x=bill_length_mm, y=bill_depth_mm)) +
+    geom_density_2d_filled(color = :black, stroke = 2)
+```
+# See also [`geom_contour`](@ref) and [`geom_density_2d`](@ref) for similar geoms.
+"""
+geom_density_2d_filled, geom_density2d_filled, geom_contour_filled

--- a/test/test_geoms.jl
+++ b/test/test_geoms.jl
@@ -858,12 +858,14 @@
     ae, ar, r, d = TidierPlots.stat_contour(
       Dict{Symbol,Pair}(
         :x => :bill_length_mm => identity,
-        :y => :bill_depth_mm => identity
+        :y => :bill_depth_mm => identity,
+        :group => :species => identity
       ),
       Dict(),
       ["x", "y"],
       @chain penguins begin
         @rename(x = bill_length_mm, y = bill_depth_mm)
+        @mutate(group = 1)
       end
     )
 
@@ -932,11 +934,13 @@
       Dict{Symbol,Pair}(
         :x => :bill_length_mm => identity,
         :y => :bill_depth_mm => identity,
+        :group => :species => identity
       ),
       Dict(),
       ["x", "y"],
       @chain penguins begin
         @rename(x = bill_length_mm, y = bill_depth_mm)
+        @mutate(group = 1)
       end
     )
 

--- a/test/test_geoms.jl
+++ b/test/test_geoms.jl
@@ -1,760 +1,962 @@
 @testset verbose = true "geoms" begin
 
-    @testset "geom_point" begin
-        t = ggplot(penguins) +
-            geom_point(@aes(x = bill_length_mm, y = bill_depth_mm))
+  @testset "geom_point" begin
+    t = ggplot(penguins) +
+        geom_point(@aes(x = bill_length_mm, y = bill_depth_mm))
 
-        t2 = ggplot() +
-             geom_point(penguins, @aes(x = bill_length_mm, y = bill_depth_mm))
+    t2 = ggplot() +
+         geom_point(penguins, @aes(x = bill_length_mm, y = bill_depth_mm))
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Scatter,
-                            penguins.bill_length_mm,
-                            penguins.bill_depth_mm)
-                    ]
-                )
-            )
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Scatter,
+              penguins.bill_length_mm,
+              penguins.bill_depth_mm)
+          ]
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
-        @test plot_images_equal(t2, m)
+    @test plot_images_equal(t, m)
+    @test plot_images_equal(t2, m)
 
-        t3 = ggplot() +
-             geom_point(penguins,
-            @aes(x = bill_length_mm, y = bill_depth_mm, color = sex))
-        t4 = ggplot() +
-             geom_point(penguins,
-            @aes(x = bill_length_mm, y = bill_depth_mm, fill = sex))
+    t3 = ggplot() +
+         geom_point(penguins,
+      @aes(x = bill_length_mm, y = bill_depth_mm, color = sex))
+    t4 = ggplot() +
+         geom_point(penguins,
+      @aes(x = bill_length_mm, y = bill_depth_mm, fill = sex))
 
-        @test plot_images_equal(t3, t4)
+    @test plot_images_equal(t3, t4)
 
-        t5 = ggplot(penguins) +
-             geom_point(
-                 @aes(x = bill_length_mm,
-                     y = bill_depth_mm,
-                     color = sex,
-                     fill = species),
-                 strokewidth=1) + guides(color="none", fill="none")
+    t5 = ggplot(penguins) +
+         geom_point(
+           @aes(x = bill_length_mm,
+             y = bill_depth_mm,
+             color = sex,
+             fill = species),
+           strokewidth=1) + guides(color="none", fill="none")
 
-        cat_species = CategoricalArrays.CategoricalArray(penguins.species)
-        cat_sex = CategoricalArrays.CategoricalArray(penguins.sex)
+    cat_species = CategoricalArrays.CategoricalArray(penguins.species)
+    cat_sex = CategoricalArrays.CategoricalArray(penguins.sex)
 
-        m2 = Makie.plot(Makie.SpecApi.GridLayout(Makie.SpecApi.Axis(
-            plots=[Makie.PlotSpec(
-                :Scatter,
-                penguins.bill_length_mm,
-                penguins.bill_depth_mm;
-                color=TidierPlots._default_discrete_palette(cat_species),
-                strokecolor=TidierPlots._default_discrete_palette(cat_sex),
-                strokewidth=1)
-            ]
-        )))
+    m2 = Makie.plot(Makie.SpecApi.GridLayout(Makie.SpecApi.Axis(
+      plots=[Makie.PlotSpec(
+        :Scatter,
+        penguins.bill_length_mm,
+        penguins.bill_depth_mm;
+        color=TidierPlots._default_discrete_palette(cat_species),
+        strokecolor=TidierPlots._default_discrete_palette(cat_sex),
+        strokewidth=1)
+      ]
+    )))
 
-        @test plot_images_equal(t5, m2)
+    @test plot_images_equal(t5, m2)
+  end
+
+
+  @testset "geom_bar" begin
+    t = ggplot(penguins) +
+        geom_bar(@aes(x = species))
+
+    penguins_count = @chain penguins begin
+      groupby(:species)
+      @summarize(count = n())
+      @arrange(species)
     end
 
-
-    @testset "geom_bar" begin
-        t = ggplot(penguins) +
-            geom_bar(@aes(x = species))
-
-        penguins_count = @chain penguins begin
-            groupby(:species)
-            @summarize(count = n())
-            @arrange(species)
-        end
-
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :BarPlot,
-                            penguins_count.count)
-                    ]; xticks=(1:3, penguins_count.species)
-                )
-            )
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :BarPlot,
+              penguins_count.count)
+          ]; xticks=(1:3, penguins_count.species)
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
+    @test plot_images_equal(t, m)
 
-        penguins_count_by_sex = @chain penguins begin
-            groupby([:species, :sex])
-            @summarize(count = n())
-            @arrange(species)
-            @ungroup
-        end
-
-        t = ggplot(penguins) +
-            geom_bar(@aes(x = species, fill = sex), position="dodge")
-
-        cat_sex = TidierPlots._default_discrete_palette(levelcode.(CategoricalArray(penguins_count_by_sex.sex)))
-        cat_spec = levelcode.(CategoricalArray(penguins_count_by_sex.species))
-        dodge = levelcode.(CategoricalArray(penguins_count_by_sex.sex))
-
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :BarPlot,
-                            cat_spec,
-                            penguins_count_by_sex.count;
-                            dodge=dodge,
-                            color=cat_sex)
-                    ]; xticks=(1:3, unique(penguins_count_by_sex.species))
-                )
-            )
-        )
-
-        @test plot_images_equal(t, m)
-
-        @test_throws ArgumentError TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :y => :c => identity,
-                :color => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :color => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:stack] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :colour => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:stack] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :group => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:stack] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :fill => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:fill] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :color => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "stack"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:stack] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :colour => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "stack"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:stack] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :group => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "stack"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:stack] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :fill => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "stack"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:fill] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :color => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:dodge] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :colour => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:dodge] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :group => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:dodge] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :fill => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:dodge] == (:a => identity)
-
-        ae, ar, r, df = TidierPlots.handle_position(
-            Dict{Symbol,Pair}(
-                :y => :b => identity,
-                :fill => :a => identity
-            ),
-            Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:dodge] == (:a => identity)
-        @test ar["direction"] == "x"
-        @test r == ["y", "x"]
+    penguins_count_by_sex = @chain penguins begin
+      groupby([:species, :sex])
+      @summarize(count = n())
+      @arrange(species)
+      @ungroup
     end
 
-    @testset "geom_col" begin
-        penguins_count = @chain penguins begin
-            groupby(:species)
-            @summarize(count = n())
-            @arrange(species)
-        end
+    t = ggplot(penguins) +
+        geom_bar(@aes(x = species, fill = sex), position="dodge")
 
-        t = ggplot(penguins_count) +
-            geom_col(@aes(x = species, y = count))
+    cat_sex = TidierPlots._default_discrete_palette(levelcode.(CategoricalArray(penguins_count_by_sex.sex)))
+    cat_spec = levelcode.(CategoricalArray(penguins_count_by_sex.species))
+    dodge = levelcode.(CategoricalArray(penguins_count_by_sex.sex))
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :BarPlot,
-                            penguins_count.count)
-                    ]; xticks=(1:3, penguins_count.species)
-                )
-            )
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :BarPlot,
+              cat_spec,
+              penguins_count_by_sex.count;
+              dodge=dodge,
+              color=cat_sex)
+          ]; xticks=(1:3, unique(penguins_count_by_sex.species))
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
+    @test plot_images_equal(t, m)
+
+    @test_throws ArgumentError TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :y => :c => identity,
+        :color => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :color => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:stack] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :colour => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:stack] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :group => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:stack] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :fill => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:fill] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :color => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "stack"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:stack] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :colour => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "stack"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:stack] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :group => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "stack"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:stack] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :fill => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "stack"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:fill] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :color => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:dodge] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :colour => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:dodge] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :group => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:dodge] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :fill => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:dodge] == (:a => identity)
+
+    ae, ar, r, df = TidierPlots.handle_position(
+      Dict{Symbol,Pair}(
+        :y => :b => identity,
+        :fill => :a => identity
+      ),
+      Dict{Any,Any}("geom_name" => "geom_bar", "position" => "dodge"),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:dodge] == (:a => identity)
+    @test ar["direction"] == "x"
+    @test r == ["y", "x"]
+  end
+
+  @testset "geom_col" begin
+    penguins_count = @chain penguins begin
+      groupby(:species)
+      @summarize(count = n())
+      @arrange(species)
     end
 
-    @testset "geom_path" begin
-        t = ggplot(penguins) +
-            geom_path(@aes(x = bill_length_mm, y = bill_depth_mm))
+    t = ggplot(penguins_count) +
+        geom_col(@aes(x = species, y = count))
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Lines,
-                            penguins.bill_length_mm,
-                            penguins.bill_depth_mm)
-                    ]
-                )
-            )
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :BarPlot,
+              penguins_count.count)
+          ]; xticks=(1:3, penguins_count.species)
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
+    @test plot_images_equal(t, m)
+  end
+
+  @testset "geom_path" begin
+    t = ggplot(penguins) +
+        geom_path(@aes(x = bill_length_mm, y = bill_depth_mm))
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Lines,
+              penguins.bill_length_mm,
+              penguins.bill_depth_mm)
+          ]
+        )
+      )
+    )
+
+    @test plot_images_equal(t, m)
+  end
+
+  @testset "geom_line" begin
+    t = ggplot(penguins) +
+        geom_line(@aes(x = bill_length_mm, y = bill_depth_mm))
+
+    perm = sortperm(penguins.bill_length_mm)
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Lines,
+              penguins.bill_length_mm[perm],
+              penguins.bill_depth_mm[perm])
+          ]
+        )
+      )
+    )
+
+    @test plot_images_equal(t, m)
+  end
+
+  @testset "geom_step" begin
+    xs = collect(rand(30) * 2pi)
+    df = DataFrame(x=xs, y=sin.(xs))
+
+    perm = sortperm(df.x)
+
+    t = ggplot(df, @aes(x = x, y = y)) + geom_step()
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Stairs,
+              df.x[perm],
+              df.y[perm])
+          ]; xlabel="x", ylabel="y"
+        )
+      )
+    )
+
+    @test plot_images_equal(t, m)
+  end
+
+  @testset "geom_boxplot" begin
+    t = ggplot(penguins) +
+        geom_boxplot(@aes(x = species, y = bill_length_mm))
+
+    cat_array = CategoricalArrays.CategoricalArray(penguins.species)
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :BoxPlot,
+              levelcode.(cat_array),
+              penguins.bill_length_mm)
+          ]; xticks=(unique(levelcode.(cat_array)),
+            unique(cat_array))
+        )
+      )
+    )
+
+    @test plot_images_equal(t, m)
+
+    ae, ar, r, d = TidierPlots.boxplot_groups(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :y => :c => identity,
+        :color => :a => identity
+      ),
+      Dict(),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
+    )
+
+    @test ae[:dodge] == (:a => identity)
+    @test ar["orientation"] == :horizontal
+
+    @test_throws ArgumentError TidierPlots.boxplot_groups(
+      Dict{Symbol,Pair}(
+        :x => :b => identity,
+        :y => :c => identity,
+        :color => :a => identity,
+        :fill => :d => identity
+      ),
+      Dict(),
+      ["x"],
+      DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"], d=["e", "f"])
+    )
+
+  end
+
+  @testset "geom_violin" begin
+    t = ggplot(penguins) +
+        geom_violin(@aes(x = species, y = bill_length_mm))
+
+    cat_array = CategoricalArrays.CategoricalArray(penguins.species)
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Violin,
+              levelcode.(cat_array),
+              penguins.bill_length_mm)
+          ]; xticks=(unique(levelcode.(cat_array)),
+            unique(cat_array))
+        )
+      )
+    )
+
+    @test plot_images_equal(t, m)
+  end
+
+  @testset "geom_hist" begin
+    t = ggplot(penguins) +
+        geom_histogram(@aes(x = bill_length_mm))
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Hist,
+              penguins.bill_length_mm)
+          ]
+        )
+      )
+    )
+
+    @test plot_images_equal(t, m)
+  end
+
+  @testset "geom_density" begin
+    t = ggplot(penguins, @aes(x = body_mass_g)) +
+        geom_density()
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        [Makie.SpecApi.Axis(
+        plots=[
+          Makie.PlotSpec(
+            :Density,
+            penguins.body_mass_g)]; xlabel="body_mass_g"
+      )]
+      )
+    )
+
+    @test plot_images_equal(t, m)
+
+    t1 = ggplot(penguins) +
+         geom_density(aes(
+        x=:bill_length_mm,
+        color=:sex,
+        fill=:species
+      ), strokewidth=1)
+
+    t2 = ggplot(penguins) +
+         geom_density(aes(
+      x=:bill_length_mm,
+      color=:sex,
+      fill=:species
+    ))
+
+    @test plot_images_equal(t1, t2)
+  end
+
+  @testset "geom_errorbar" begin
+    categories = [1, 2, 3, 4]
+    n = length(categories)
+
+    mean_values = rand(n)  # Random mean values for demonstration
+    errors = rand(n) / 2   # Random error values for demonstration
+
+    LowerBound = mean_values .- errors
+    UpperBound = mean_values .+ errors
+
+    df_errorbar = DataFrame(
+      cat_numeric=categories,
+      MeanValue=mean_values,
+      LowerBound=LowerBound,
+      UpperBound=UpperBound)
+
+    t = ggplot(df_errorbar, @aes(x = cat_numeric, y = MeanValue, ymin = LowerBound, ymax = UpperBound)) +
+        geom_point() + # to show the mean value
+        geom_errorbar() # width of the horizontal line at the top and bottom of the error bar
+
+    t2 = @chain ggplot(df_errorbar, @aes(x = cat_numeric, y = MeanValue, ymin = LowerBound, ymax = UpperBound)) begin
+      geom_point()
+      geom_errorbar()
     end
 
-    @testset "geom_line" begin
-        t = ggplot(penguins) +
-            geom_line(@aes(x = bill_length_mm, y = bill_depth_mm))
-
-        perm = sortperm(penguins.bill_length_mm)
-
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Lines,
-                            penguins.bill_length_mm[perm],
-                            penguins.bill_depth_mm[perm])
-                    ]
-                )
-            )
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Scatter,
+              df_errorbar.cat_numeric,
+              df_errorbar.MeanValue),
+            Makie.PlotSpec(
+              :Rangebars,
+              df_errorbar.cat_numeric,
+              df_errorbar.LowerBound,
+              df_errorbar.UpperBound)
+          ]; xlabel="cat_numeric", ylabel="MeanValue"
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
+    @test plot_images_equal(t, m)
+    @test plot_images_equal(t2, m)
+
+    t3 = @chain ggplot(df_errorbar, @aes(y = cat_numeric, x = MeanValue, xmin = LowerBound, xmax = UpperBound)) begin
+      geom_point()
+      geom_errorbarh()
     end
 
-    @testset "geom_step" begin
-        xs = collect(rand(30) * 2pi)
-        df = DataFrame(x=xs, y=sin.(xs))
+    t4 = ggplot(df_errorbar, @aes(y = cat_numeric, x = MeanValue, xmin = LowerBound, xmax = UpperBound)) +
+         geom_point() + # to show the mean value
+         geom_errorbarh()
 
-        perm = sortperm(df.x)
-
-        t = ggplot(df, @aes(x = x, y = y)) + geom_step()
-
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Stairs,
-                            df.x[perm],
-                            df.y[perm])
-                    ]; xlabel="x", ylabel="y"
-                )
-            )
+    m2 = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Scatter,
+              df_errorbar.MeanValue,
+              df_errorbar.cat_numeric),
+            Makie.PlotSpec(
+              :Rangebars,
+              df_errorbar.cat_numeric,
+              df_errorbar.LowerBound,
+              df_errorbar.UpperBound; direction=:x)
+          ]; xlabel="cat_numeric", ylabel="MeanValue"
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
+    @test plot_images_equal(t3, m2)
+    @test plot_images_equal(t4, m2)
+
+  end
+
+  @testset "geom_smooth" begin
+    t = ggplot(penguins, aes(x="bill_length_mm", y="bill_depth_mm")) +
+        geom_smooth() + geom_point()
+
+    model = Loess.loess(penguins.bill_length_mm, penguins.bill_depth_mm; span=0.75, degree=2)
+    x̂ = range(extrema(penguins.bill_length_mm)..., length=200)
+    ŷ = Loess.predict(model, x̂)
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Lines,
+              x̂,
+              ŷ),
+            Makie.PlotSpec(
+              :Scatter,
+              penguins.bill_length_mm,
+              penguins.bill_depth_mm
+            )
+          ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
+        )
+      )
+    )
+
+    @test plot_images_equal(t, m)
+
+    t2 = @chain ggplot(penguins, aes(x="bill_length_mm", y="bill_depth_mm")) begin
+      geom_smooth
+      geom_point
     end
 
-    @testset "geom_boxplot" begin
-        t = ggplot(penguins) +
-            geom_boxplot(@aes(x = species, y = bill_length_mm))
+    @test plot_images_equal(t, t2)
 
-        cat_array = CategoricalArrays.CategoricalArray(penguins.species)
+    t = ggplot(penguins, aes(x="bill_length_mm", y="bill_depth_mm")) +
+        geom_smooth(method="lm") + geom_point()
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :BoxPlot,
-                            levelcode.(cat_array),
-                            penguins.bill_length_mm)
-                    ]; xticks=(unique(levelcode.(cat_array)),
-                        unique(cat_array))
-                )
-            )
-        )
 
-        @test plot_images_equal(t, m)
+    function add_intercept_column(x::AbstractVector{T}) where {T}
+      mat = similar(x, float(T), (length(x), 2))
+      fill!(view(mat, :, 1), 1)
+      copyto!(view(mat, :, 2), x)
+      return mat
+    end
 
-        ae, ar, r, d = TidierPlots.boxplot_groups(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :y => :c => identity,
-                :color => :a => identity
+    lin_model = GLM.lm(add_intercept_column(penguins.bill_length_mm), penguins.bill_depth_mm)
+    x̂ = range(extrema(penguins.bill_length_mm)..., length=100)
+    pred = DataFrame(GLM.predict(lin_model, add_intercept_column(x̂); interval=:confidence))
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Lines,
+              x̂,
+              pred.prediction),
+            Makie.PlotSpec(
+              :Scatter,
+              penguins.bill_length_mm,
+              penguins.bill_depth_mm
             ),
-            Dict(),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"])
-        )
-
-        @test ae[:dodge] == (:a => identity)
-        @test ar["orientation"] == :horizontal
-
-        @test_throws ArgumentError TidierPlots.boxplot_groups(
-            Dict{Symbol,Pair}(
-                :x => :b => identity,
-                :y => :c => identity,
-                :color => :a => identity,
-                :fill => :d => identity
-            ),
-            Dict(),
-            ["x"],
-            DataFrame(a=["a", "b"], b=[1, 2], c=["c", "d"], d=["e", "f"])
-        )
-
-    end
-
-    @testset "geom_violin" begin
-        t = ggplot(penguins) +
-            geom_violin(@aes(x = species, y = bill_length_mm))
-
-        cat_array = CategoricalArrays.CategoricalArray(penguins.species)
-
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Violin,
-                            levelcode.(cat_array),
-                            penguins.bill_length_mm)
-                    ]; xticks=(unique(levelcode.(cat_array)),
-                        unique(cat_array))
-                )
+            Makie.PlotSpec(
+              :Band,
+              x̂,
+              pred.lower,
+              pred.upper; alpha=0.6
             )
+          ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
-    end
+    @test plot_images_equal(t, m)
 
-    @testset "geom_hist" begin
-        t = ggplot(penguins) +
-            geom_histogram(@aes(x = bill_length_mm))
+  end
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Hist,
-                            penguins.bill_length_mm)
-                    ]
-                )
+  @testset "geom_text" begin
+    t = ggplot(penguins) +
+        geom_text(aes(x=:bill_length_mm, y=:bill_depth_mm, text=:species))
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Text,
+              penguins.bill_length_mm,
+              penguins.bill_depth_mm;
+              text=String.(penguins.species))
+          ]
+        )
+      )
+    )
+
+    @test plot_images_equal(t, m)
+
+  end
+
+  @testset "geom_hline" begin
+    yint = 2.5
+
+    t = ggplot(penguins) +
+        geom_hline(yintercept=yint)
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :HLines,
+              yint
             )
+          ]
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
-    end
+    @test plot_images_equal(t, m)
 
-    @testset "geom_density" begin
-        t = ggplot(penguins, @aes(x = body_mass_g)) +
-            geom_density()
+    t2 = geom_hline(ggplot(penguins), yintercept=yint)
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                [Makie.SpecApi.Axis(
-                plots=[
-                    Makie.PlotSpec(
-                        :Density,
-                        penguins.body_mass_g)]; xlabel="body_mass_g"
-            )]
+    @test plot_images_equal(t, t2)
+  end
+
+  @testset "geom_vline" begin
+    xint = 2.5
+
+    t = ggplot() +
+        geom_vline(xintercept=xint)
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :VLines,
+              xint
             )
+          ]
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
+    @test plot_images_equal(t, m)
 
-        t1 = ggplot(penguins) +
-             geom_density(aes(
-                x=:bill_length_mm,
-                color=:sex,
-                fill=:species
-            ), strokewidth=1)
+    t2 = geom_vline(ggplot(penguins), xintercept=xint)
 
-        t2 = ggplot(penguins) +
-             geom_density(aes(
-            x=:bill_length_mm,
-            color=:sex,
-            fill=:species
-        ))
+    @test plot_images_equal(t, t2)
+  end
 
-        @test plot_images_equal(t1, t2)
-    end
+  @testset "geom_rainclouds" begin
+    t = ggplot(penguins) +
+        geom_rainclouds(@aes(x = species, y = bill_length_mm))
 
-    @testset "geom_errorbar" begin
-        categories = [1, 2, 3, 4]
-        n = length(categories)
+    cat_array = CategoricalArrays.CategoricalArray(penguins.species)
 
-        mean_values = rand(n)  # Random mean values for demonstration
-        errors = rand(n) / 2   # Random error values for demonstration
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :RainClouds,
+              levelcode.(cat_array),
+              penguins.bill_length_mm)
+          ]; xticks=(unique(levelcode.(cat_array)),
+            unique(cat_array))
+        )
+      )
+    )
 
-        LowerBound = mean_values .- errors
-        UpperBound = mean_values .+ errors
+    @test plot_images_equal(t, m)
 
-        df_errorbar = DataFrame(
-            cat_numeric=categories,
-            MeanValue=mean_values,
-            LowerBound=LowerBound,
-            UpperBound=UpperBound)
+    t2 = geom_rainclouds(ggplot(penguins),
+      @aes(x = species, y = bill_length_mm))
 
-        t = ggplot(df_errorbar, @aes(x = cat_numeric, y = MeanValue, ymin = LowerBound, ymax = UpperBound)) +
-            geom_point() + # to show the mean value
-            geom_errorbar() # width of the horizontal line at the top and bottom of the error bar
+    @test plot_images_equal(t, t2)
+  end
 
-        t2 = @chain ggplot(df_errorbar, @aes(x = cat_numeric, y = MeanValue, ymin = LowerBound, ymax = UpperBound)) begin
-            geom_point()
-            geom_errorbar()
-        end
+  @testset "geom_contour" begin
+    t = ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm)) +
+        geom_contour()
+    ae, ar, r, d = TidierPlots.stat_contour(
+      Dict{Symbol,Pair}(
+        :x => :bill_length_mm => identity,
+        :y => :bill_depth_mm => identity
+      ),
+      Dict(),
+      ["x", "y"],
+      @chain penguins begin
+        @rename(x = bill_length_mm, y = bill_depth_mm)
+        @mutate(group = 1)
+      end
+    )
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Scatter,
-                            df_errorbar.cat_numeric,
-                            df_errorbar.MeanValue),
-                        Makie.PlotSpec(
-                            :Rangebars,
-                            df_errorbar.cat_numeric,
-                            df_errorbar.LowerBound,
-                            df_errorbar.UpperBound)
-                    ]; xlabel="cat_numeric", ylabel="MeanValue"
-                )
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Contour,
+              d.x,
+              d.y,
+              d.z;
             )
+          ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
         )
+      )
+    )
+    @test plot_images_equal(t, m)
+  end
 
-        @test plot_images_equal(t, m)
-        @test plot_images_equal(t2, m)
+  @testset "geom_contour_filled" begin
+    t = ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm)) +
+        geom_contour_filled()
+    ae, ar, r, d = TidierPlots.stat_contour(
+      Dict{Symbol,Pair}(
+        :x => :bill_length_mm => identity,
+        :y => :bill_depth_mm => identity
+      ),
+      Dict(),
+      ["x", "y"],
+      @chain penguins begin
+        @rename(x = bill_length_mm, y = bill_depth_mm)
+        @mutate(group = 1)
+      end
+    )
 
-        t3 = @chain ggplot(df_errorbar, @aes(y = cat_numeric, x = MeanValue, xmin = LowerBound, xmax = UpperBound)) begin
-            geom_point()
-            geom_errorbarh()
-        end
-
-        t4 = ggplot(df_errorbar, @aes(y = cat_numeric, x = MeanValue, xmin = LowerBound, xmax = UpperBound)) +
-             geom_point() + # to show the mean value
-             geom_errorbarh()
-
-        m2 = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Scatter,
-                            df_errorbar.MeanValue,
-                            df_errorbar.cat_numeric),
-                        Makie.PlotSpec(
-                            :Rangebars,
-                            df_errorbar.cat_numeric,
-                            df_errorbar.LowerBound,
-                            df_errorbar.UpperBound; direction=:x)
-                    ]; xlabel="cat_numeric", ylabel="MeanValue"
-                )
-            )
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Contourf,
+              d.x,
+              d.y,
+              d.z;
+              levels=10)
+          ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
         )
+      )
+    )
+    @test plot_images_equal(t, m)
+  end
 
-        @test plot_images_equal(t3, m2)
-        @test plot_images_equal(t4, m2)
 
-    end
+  @testset "geom_density_2d" begin
+    ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm)) +
+    geom_density2d(breaks=10)
+    @test_throws ArgumentError TidierPlots.stat_contour(
+      Dict{Symbol,Pair}(
+        :x => :bill_length_mm => identity
+      ),
+      Dict(),
+      ["x"],
+      @chain penguins begin
+        @rename(x = bill_length_mm)
+      end
+    )
 
-    @testset "geom_smooth" begin
-        t = ggplot(penguins, aes(x="bill_length_mm", y="bill_depth_mm")) +
-            geom_smooth() + geom_point()
+    @test_warn "Equal x and y aesthetics detected. This may not be intended." TidierPlots.stat_contour(
+      Dict{Symbol,Pair}(
+        :x => :bill_length_mm => identity,
+        :y => :bill_length_mm => identity
+      ),
+      Dict(),
+      ["x", "y"],
+      @chain penguins begin
+        @mutate(x = bill_length_mm, y = bill_length_mm, group = 1)
+      end
+    )
 
-        model = Loess.loess(penguins.bill_length_mm, penguins.bill_depth_mm; span=0.75, degree=2)
-        x̂ = range(extrema(penguins.bill_length_mm)..., length=200)
-        ŷ = Loess.predict(model, x̂)
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Lines,
-                            x̂,
-                            ŷ),
-                        Makie.PlotSpec(
-                            :Scatter,
-                            penguins.bill_length_mm,
-                            penguins.bill_depth_mm
-                        )
-                    ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
-                )
-            )
+    t = ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm)) +
+        geom_density_2d(breaks=10)
+
+    ae, ar, r, d = TidierPlots.stat_contour(
+      Dict{Symbol,Pair}(
+        :x => :bill_length_mm => identity,
+        :y => :bill_depth_mm => identity
+      ),
+      Dict(),
+      ["x", "y"],
+      @chain penguins begin
+        @rename(x = bill_length_mm, y = bill_depth_mm)
+      end
+    )
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Contour,
+              d.x,
+              d.y,
+              d.z;
+              levels=10)
+          ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
-
-        t2 = @chain ggplot(penguins, aes(x="bill_length_mm", y="bill_depth_mm")) begin
-            geom_smooth
-            geom_point
-        end
-
-        @test plot_images_equal(t, t2)
-
-        t = ggplot(penguins, aes(x="bill_length_mm", y="bill_depth_mm")) +
-            geom_smooth(method="lm") + geom_point()
+    @test plot_images_equal(t, m)
 
 
-        function add_intercept_column(x::AbstractVector{T}) where {T}
-            mat = similar(x, float(T), (length(x), 2))
-            fill!(view(mat, :, 1), 1)
-            copyto!(view(mat, :, 2), x)
-            return mat
-        end
+    t2 = ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm, group = species)) +
+         geom_density_2d()
 
-        lin_model = GLM.lm(add_intercept_column(penguins.bill_length_mm), penguins.bill_depth_mm)
-        x̂ = range(extrema(penguins.bill_length_mm)..., length=100)
-        pred = DataFrame(GLM.predict(lin_model, add_intercept_column(x̂); interval=:confidence))
+    ae2, ar2, r2, d2 = TidierPlots.stat_contour(
+      Dict{Symbol,Pair}(
+        :x => :bill_length_mm => identity,
+        :y => :bill_depth_mm => identity,
+        :group => :species => identity
+      ),
+      Dict(),
+      ["x", "y"],
+      @chain penguins begin
+        @rename(x = bill_length_mm, y = bill_depth_mm, group = species)
+      end
+    )
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Lines,
-                            x̂,
-                            pred.prediction),
-                        Makie.PlotSpec(
-                            :Scatter,
-                            penguins.bill_length_mm,
-                            penguins.bill_depth_mm
-                        ),
-                        Makie.PlotSpec(
-                            :Band,
-                            x̂,
-                            pred.lower,
-                            pred.upper; alpha=0.6
-                        )
-                    ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
-                )
-            )
+    m2 = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Contour,
+              d2.x[d2.group.==g],
+              d2.y[d2.group.==g],
+              d2.z[d2.group.==g],
+            ) for g in unique(d2.group)
+          ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
+    @test plot_images_equal(t2, m2)
 
-    end
+  end
 
-    @testset "geom_text" begin
-        t = ggplot(penguins) +
-            geom_text(aes(x=:bill_length_mm, y=:bill_depth_mm, text=:species))
 
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :Text,
-                            penguins.bill_length_mm,
-                            penguins.bill_depth_mm;
-                            text=String.(penguins.species))
-                    ]
-                )
-            )
+  @testset "geom_density_2d_filled" begin
+    ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm)) +
+    geom_density2d_filled()
+
+    t = ggplot(penguins, @aes(x = bill_length_mm, y = bill_depth_mm)) +
+        geom_density_2d_filled()
+
+    ae, ar, r, d = TidierPlots.stat_contour(
+      Dict{Symbol,Pair}(
+        :x => :bill_length_mm => identity,
+        :y => :bill_depth_mm => identity,
+      ),
+      Dict(),
+      ["x", "y"],
+      @chain penguins begin
+        @rename(x = bill_length_mm, y = bill_depth_mm)
+      end
+    )
+
+    m = Makie.plot(
+      Makie.SpecApi.GridLayout(
+        Makie.SpecApi.Axis(
+          plots=[
+            Makie.PlotSpec(
+              :Contourf,
+              d.x,
+              d.y,
+              d.z)
+          ]; xlabel="bill_length_mm", ylabel="bill_depth_mm"
         )
+      )
+    )
 
-        @test plot_images_equal(t, m)
 
-    end
+    @test plot_images_equal(t, m)
 
-    @testset "geom_hline" begin
-        yint = 2.5
+  end
 
-        t = ggplot(penguins) +
-            geom_hline(yintercept=yint)
-
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :HLines,
-                            yint
-                        )
-                    ]
-                )
-            )
-        )
-
-        @test plot_images_equal(t, m)
-
-        t2 = geom_hline(ggplot(penguins), yintercept=yint)
-
-        @test plot_images_equal(t, t2)
-    end
-
-    @testset "geom_vline" begin
-        xint = 2.5
-
-        t = ggplot() +
-            geom_vline(xintercept=xint)
-
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :VLines,
-                            xint
-                        )
-                    ]
-                )
-            )
-        )
-
-        @test plot_images_equal(t, m)
-
-        t2 = geom_vline(ggplot(penguins), xintercept=xint)
-
-        @test plot_images_equal(t, t2)
-    end
-
-    @testset "geom_rainclouds" begin
-        t = ggplot(penguins) +
-            geom_rainclouds(@aes(x = species, y = bill_length_mm))
-
-        cat_array = CategoricalArrays.CategoricalArray(penguins.species)
-
-        m = Makie.plot(
-            Makie.SpecApi.GridLayout(
-                Makie.SpecApi.Axis(
-                    plots=[
-                        Makie.PlotSpec(
-                            :RainClouds,
-                            levelcode.(cat_array),
-                            penguins.bill_length_mm)
-                    ]; xticks=(unique(levelcode.(cat_array)),
-                        unique(cat_array))
-                )
-            )
-        )
-
-        @test plot_images_equal(t, m)
-
-        t2 = geom_rainclouds(ggplot(penguins),
-            @aes(x = species, y = bill_length_mm))
-
-        @test plot_images_equal(t, t2)
-    end
 end


### PR DESCRIPTION
This implements `geom_density_2d` and `geom_contour` along with the filled versions of both. These functions are functionally identical outside their usage of `after_stat()` which is not yet implemented in `TidierPlots`. 

From here I have 2 ideas/suggestions. 
1. implementing `after_stat()`. This allows coloring by level in each plot, because right now coloring ability is basic without it.
2. Do we want to make `stat_contour` it's own quasi geom? Right now, I implemented it similar to the `stat_*` functions in `geom_smooth`, which are meant to be called internally. However, I can see a need for the xyz format of the original `stat_contour`. If we do that, then opening up broader usage of `stat` geoms seems reasonable. Consequently, the internal conversion functions should be renamed. 